### PR TITLE
Add temporary fix so that IDR link resolves to latest issued VC

### DIFF
--- a/app/src/modules/link-resolution/utils/link-resolution.utils.ts
+++ b/app/src/modules/link-resolution/utils/link-resolution.utils.ts
@@ -41,7 +41,7 @@ const processUriForSpecificLinkType = (
   uri: Uri,
   identifierParams: LinkResolutionDto,
 ): ResolvedLink | undefined => {
-  const responses = uri.responses.filter((res) => res.active);
+  const responses = uri.responses.filter((res) => res.active).reverse(); // Temporary fix so that IDR Link resolves to latest issued VC
   const {
     linkType,
     ianaLanguageContexts = [],


### PR DESCRIPTION
Reversed the response array in app/src/modules/link-resolution/utils/link-resolution.utils.ts so that the latest issued VC will be returned instead of the first issued