### PR TITLE
ci: seperate coverage report workflow

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -1,0 +1,31 @@
+name: Report Coverage
+on:
+  workflow_run:
+    workflows: ["Test Build"]
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+
+      - name: Coverage Report
+        uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file: coverage/report.json
+          base-coverage-file: coverage/report.json
+          threshold: 80

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -40,14 +40,11 @@ jobs:
         run: npm run test -- --ci --json --coverage --testLocationInResults --outputFile=report.json
         working-directory: app
 
-      - name: Coverage
-        uses: artiomtr/jest-coverage-report-action@v2
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # read coverage report from JSON file generated in the previous step and compare it with the base coverage
-          coverage-file: app/report.json
-          base-coverage-file: app/report.json
-          threshold: 80 # set the minimum coverage threshold to 80%
+          name: coverage-report
+          path: app/report.json
 
   build_docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request isolates the coverage reporting step into a dedicated workflow to address the issue encountered when contributors submit PRs from forks without granting write permissions to the build test workflow.