### PR TITLE
test: add coverage threshold

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -36,18 +36,8 @@ jobs:
         working-directory: app
 
       - name: Run tests
-        # run tests only on changed files and generate coverage report in JSON format
-        run: npm run test -- --ci --json --coverage --testLocationInResults --outputFile=report.json
+        run: npm run test -- --ci --json --coverage --testLocationInResults
         working-directory: app
-
-      - name: Coverage
-        uses: artiomtr/jest-coverage-report-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # read coverage report from JSON file generated in the previous step and compare it with the base coverage
-          coverage-file: app/report.json
-          base-coverage-file: app/report.json
-          threshold: 80 # set the minimum coverage threshold to 80%
 
   build_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: app
 
       - name: Run tests
-        run: npm run test -- --ci --json --coverage --testLocationInResults
+        run: npm run test -- --ci --coverage
         working-directory: app
 
   build_docs:

--- a/app/package.json
+++ b/app/package.json
@@ -98,10 +98,10 @@
     "testEnvironment": "node",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -98,10 +98,10 @@
     "testEnvironment": "node",
     "coverageThreshold": {
       "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100,
-        "statements": 100
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -95,6 +95,14 @@
       "./__mocks__/jest-setup-file.ts"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    }
   }
 }


### PR DESCRIPTION
The pull request relocates the test coverage threshold (quality gate) from the `artiomtr/jest-coverage-report-action@v2` action to the Jest configuration. This change enables the removal of the `artiomtr/jest-coverage-report-action@v2` action, which was blocking contributions from forks.

#### Test run
<img width="1746" alt="Screenshot 2025-05-28 at 11 42 07 am" src="https://github.com/user-attachments/assets/a2a8d669-6eee-4794-8aff-6a693f9a35b6" />


<img width="1411" alt="Screenshot 2025-05-28 at 12 19 58 pm" src="https://github.com/user-attachments/assets/4759e44c-7715-4cb6-aef7-1c4711290325" />

