### PR TITLE
fix(ci): skip release if tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,22 @@ jobs:
           fi
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
 
+      # Check if the tag already exists
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          new_version=${{ steps.retrieve_version.outputs.new_version }}
+          if git ls-remote --tags origin | grep -q "refs/tags/$new_version$"; then
+            echo "Tag $new_version already exists, skipping release"
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $new_version does not exist, proceeding with release"
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Create tag to the repository by using the version from the output file
       - name: Create tag
+        if: steps.check_tag.outputs.tag_exists == 'false'
         id: create-tag
         run: |
           new_version=${{ steps.retrieve_version.outputs.new_version }}
@@ -79,6 +93,7 @@ jobs:
 
       # Create GitHub release
       - name: Create GitHub Release
+        if: steps.check_tag.outputs.tag_exists == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Fixes the release pipeline failing when the version tag already exists.

## Problem

The release pipeline triggers on every push to `master`, but it always tries to create a tag based on the version in `version.json`. When a non-release PR is merged (e.g., documentation updates, workflow fixes), the pipeline fails because the tag already exists from the previous release.

## Solution

Added a check step that verifies whether the tag already exists before attempting to create it:

1. **Check if tag exists** - Uses `git ls-remote --tags` to check if the version tag exists on the remote
2. **Skip if exists** - If the tag exists, the "Create tag" and "Create GitHub Release" steps are skipped

This allows non-release PRs to be merged to `master` without causing pipeline failures.