### PR TITLE
fix(ci): add multi-platform builds and version tags for workflow_run

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Get version from version.json for workflow_run triggers
+      - name: Get version from version.json
+        id: get_version
+        run: |
+          VERSION=$(jq -r '.version' version.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: docker meta details
         id: meta
         uses: docker/metadata-action@v5
@@ -41,8 +48,13 @@ jobs:
             type=edge,branch=master
             type=semver,pattern={{version}}
             type=sha
+            type=raw,value=${{ steps.get_version.outputs.version }},enable=${{ github.event_name == 'workflow_run' }}
 
-      - name: Set up Docker
+      # Set up QEMU for multi-platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Github Container Registry
@@ -56,6 +68,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ env.PUSH_CONDITION }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}-local
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
@@ -64,6 +77,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ env.PUSH_CONDITION }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}-serverless
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.serverless


### PR DESCRIPTION
## Summary

Fixes two issues with the Package workflow:

### 1. Missing version tags when triggered via workflow_run

When the Package workflow is triggered via `workflow_run` (after Release completes), the `github.ref` is `refs/heads/master`, not a tag ref. This means `type=semver,pattern={{version}}` doesn't match, and only `edge` and `sha-*` tags are created.

**Fix:** Added a step to read version from `version.json` and use it as a `type=raw` tag when triggered via `workflow_run`.

### 2. Single-platform builds (amd64 only)

Images were only built for `linux/amd64`, causing issues on Apple Silicon Macs (requires emulation).

**Fix:** Added QEMU setup and `platforms: linux/amd64,linux/arm64` for multi-platform builds.

## Changes

- Added step to read version from `version.json`
- Added `type=raw` tag using version for `workflow_run` triggers
- Added QEMU setup for cross-platform builds
- Added `platforms: linux/amd64,linux/arm64` to both image builds