### PR TITLE
fix(ci): use separate metadata with suffix for local and serverless images

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,13 +37,29 @@ jobs:
           VERSION=$(jq -r '.version' version.json)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: docker meta details
-        id: meta
+      # Metadata for standard image (no suffix - this is the default)
+      - name: Docker meta for standard image
+        id: meta-standard
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{github.repository}}
           flavor: |
             latest=auto
+          tags: |
+            type=edge,branch=master
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=${{ steps.get_version.outputs.version }},enable=${{ github.event_name == 'workflow_run' }}
+
+      # Metadata for serverless image (with -serverless suffix)
+      - name: Docker meta for serverless image
+        id: meta-serverless
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{github.repository}}
+          flavor: |
+            latest=false
+            suffix=-serverless
           tags: |
             type=edge,branch=master
             type=semver,pattern={{version}}
@@ -64,13 +80,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Local Image
+      - name: Build and Push Standard Image
         uses: docker/build-push-action@v5
         with:
           push: ${{ env.PUSH_CONDITION }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}-local
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-standard.outputs.tags }}
+          labels: ${{ steps.meta-standard.outputs.labels }}
           file: Dockerfile
 
       - name: Build and Push Serverless Image
@@ -78,6 +94,6 @@ jobs:
         with:
           push: ${{ env.PUSH_CONDITION }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}-serverless
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-serverless.outputs.tags }}
+          labels: ${{ steps.meta-serverless.outputs.labels }}
           file: Dockerfile.serverless

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ docker compose up -d
 
 For more detailed setup and configuration options, refer to the [documentation site](https://pyx-industries.github.io/pyx-identity-resolver/).
 
+## Docker Images
+
+Pre-built Docker images are available on [GitHub Container Registry](https://github.com/pyx-industries/pyx-identity-resolver/pkgs/container/pyx-identity-resolver). Two variants are provided:
+
+| Image | Use Case |
+|-------|----------|
+| Default (no suffix) | Standard deployment, local development |
+| `-serverless` | AWS Lambda / serverless deployments |
+
+Both images support `linux/amd64` and `linux/arm64` architectures.
+
+### Pulling Images
+
+```bash
+# Standard image (default)
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2
+
+# Serverless image (Lambda deployment)
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2-serverless
+```
+
+For more details on available tags, see the [Package workflow documentation](./docs/ci/package.md).
+
 ## Contributing
 
 We use [Semantic Line Breaks](https://sembr.org/) in our documentation. Please follow this convention when contributing to the project.

--- a/docs/ci/package.md
+++ b/docs/ci/package.md
@@ -2,44 +2,87 @@
 
 ## Overview
 
-The Package workflow is responsible for building and pushing Docker images
-for the Identity Resolver Service (IDR) application.
+The Package workflow builds and pushes Docker images for the Identity Resolver application to GitHub Container Registry (GHCR).
 
 ## Trigger
 
 This workflow is triggered on:
 
-- Push of tags matching the pattern "v*.*.\*" (e.g., v1.0.0)
-- Manual trigger via workflow_dispatch
-- Completion of the 'Release Tagging' workflow
+- Push of tags matching the pattern `*.*.*` (e.g., `1.1.2`)
+- Manual trigger via `workflow_dispatch`
+- Completion of the `Release` workflow
 
-## Workflow Details
+## Docker Images
 
-### Environment Variables
+The workflow builds two image variants:
 
-- CI: true
+| Image Type | Dockerfile | Use Case |
+|------------|------------|----------|
+| **Standard** | `Dockerfile` | Standard deployment, local development |
+| **Serverless** | `Dockerfile.serverless` | AWS Lambda / serverless deployments |
 
-### Steps
+### Multi-Platform Support
+
+Both images are built for multiple architectures:
+- `linux/amd64` (Intel/AMD)
+- `linux/arm64` (Apple Silicon, ARM servers)
+
+### Image Tags
+
+The standard image uses unadorned tags, while the serverless variant uses a `-serverless` suffix:
+
+| Tag Pattern | Example | Description |
+|-------------|---------|-------------|
+| `{version}` | `1.1.2` | Version-tagged standard image |
+| `{version}-serverless` | `1.1.2-serverless` | Version-tagged serverless image |
+| `latest` | `latest` | Latest release (standard) |
+| `edge` | `edge` | Latest from master (standard) |
+| `edge-serverless` | `edge-serverless` | Latest from master (serverless) |
+| `sha-{hash}` | `sha-f30ab65` | Commit-specific standard image |
+| `sha-{hash}-serverless` | `sha-f30ab65-serverless` | Commit-specific serverless image |
+
+## Pulling Images
+
+### Standard Image (Default)
+
+```bash
+# Latest release
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2
+
+# Or use latest tag
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:latest
+
+# Latest from master
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:edge
+```
+
+### Serverless Image (Lambda Deployment)
+
+```bash
+# Latest release
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2-serverless
+
+# Latest from master
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:edge-serverless
+```
+
+## Workflow Steps
 
 1. **Checkout**: Fetches the repository code
-2. **Docker meta details**: Extracts metadata for Docker images
-3. **Set up Docker**: Prepares the Docker buildx environment
-4. **Login to Github Container Registry**: Authenticates with GitHub Container Registry
-5. **Build and Push Local Image**: Builds and pushes the local version of the Docker image
-6. **Build and Push Serverless Image**: Builds and pushes the serverless version of the Docker image (used for deployment)
+2. **Get version**: Reads version from `version.json` for `workflow_run` triggers
+3. **Docker meta (standard)**: Generates tags for standard image
+4. **Docker meta (serverless)**: Generates tags with `-serverless` suffix
+5. **Set up QEMU**: Enables multi-platform builds
+6. **Set up Docker Buildx**: Prepares the Docker buildx environment
+7. **Login to GHCR**: Authenticates with GitHub Container Registry
+8. **Build and Push Standard Image**: Builds and pushes the standard image
+9. **Build and Push Serverless Image**: Builds and pushes the serverless image
 
 ## Dependencies
 
-- actions/checkout@v4
-- docker/metadata-action@v5
-- docker/setup-buildx-action@v3
-- docker/login-action@v3
-- docker/build-push-action@v5
-
-## Notes
-
-- The workflow builds two versions of the Docker image: local and serverless
-- Images are tagged with version numbers, latest (for master branch), and commit SHA
-- Images are only pushed to the registry when the workflow is triggered by a tag push
-- The workflow uses the `app/Dockerfile` for the local image
-  and `app/Dockerfile.serverless` for the serverless image
+- `actions/checkout@v4`
+- `docker/metadata-action@v5`
+- `docker/setup-qemu-action@v3`
+- `docker/setup-buildx-action@v3`
+- `docker/login-action@v3`
+- `docker/build-push-action@v5

--- a/documentation/docs/getting-started/quick-start.md
+++ b/documentation/docs/getting-started/quick-start.md
@@ -30,4 +30,18 @@ docker compose up -d
 
 The default configuration and examples within the API documentation will be sufficient for you to get started. When you are ready, you can find more detailed setup and configuration options [here](docs/getting-started/configuration.md).
 
+## Using Pre-built Docker Images
+
+Alternatively, you can pull pre-built images directly from [GitHub Container Registry](https://github.com/pyx-industries/pyx-identity-resolver/pkgs/container/pyx-identity-resolver):
+
+```bash
+# Standard image (default)
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2
+
+# Serverless image (AWS Lambda deployment)
+docker pull ghcr.io/pyx-industries/pyx-identity-resolver:1.1.2-serverless
+```
+
+Both images support `linux/amd64` and `linux/arm64` architectures.
+
 ---


### PR DESCRIPTION
## Summary

Fixes Docker image tagging and adds documentation.

## Changes

### Tag Structure (Simplified)

Removed `-local` suffix from standard image - it's now the default:

| Tag | Image |
|-----|-------|
| `1.1.2` | Standard deployment |
| `1.1.2-serverless` | AWS Lambda deployment |
| `latest` | Latest release (standard) |
| `edge` | Latest from master (standard) |
| `edge-serverless` | Latest from master (serverless) |

### Documentation Added

- **README.md** - Added Docker Images section with pull instructions and link to GHCR
- **docs/ci/package.md** - Updated with correct tag patterns and pull examples
- **documentation/docs/getting-started/quick-start.md** - Added pre-built image section

### Workflow Changes

- Standard image now uses unadorned tags (no suffix)
- Enabled `latest` tag for standard image (`latest=auto`)
- Serverless image keeps `-serverless` suffix