### PR TITLE
feat(link-registration): add UNTP linkset extensions and predecessor-version support

### DIFF
--- a/app/src/modules/common/common.service.spec.ts
+++ b/app/src/modules/common/common.service.spec.ts
@@ -83,6 +83,11 @@ describe('CommonService Success Cases', () => {
           prefix: 'example:',
           profile: `${RESOLVER_DOMAIN}/voc/?show=linktypes`,
         },
+        {
+          namespace: 'https://test.uncefact.org/untp/linkType#',
+          prefix: 'untp:',
+          profile: 'https://untp.unece.org/docs/specification/IdentityResolver',
+        },
       ],
       supportedPrimaryKeys: ['all'],
     });
@@ -129,6 +134,11 @@ describe('CommonService Success Cases', () => {
           namespace: 'http://integrity-system.org/',
           prefix: 'integrity-system:',
           profile: 'http://integrity-system.org/?show=linktypes',
+        },
+        {
+          namespace: 'https://test.uncefact.org/untp/linkType#',
+          prefix: 'untp:',
+          profile: 'https://untp.unece.org/docs/specification/IdentityResolver',
         },
       ],
       supportedPrimaryKeys: ['all'],

--- a/app/src/modules/common/common.service.ts
+++ b/app/src/modules/common/common.service.ts
@@ -62,7 +62,7 @@ export class CommonService {
 
   private async mapSupportedLinkTypes(): Promise<SupportedLinkType[]> {
     const identifiers = await this.identifierService.getIdentifiers();
-    return Object.keys(identifiers).map((key) => {
+    const identifierLinkTypes = Object.keys(identifiers).map((key) => {
       return {
         namespace:
           identifiers[key].namespaceURI && identifiers[key].namespaceURI !== ''
@@ -76,6 +76,15 @@ export class CommonService {
             : `${this.configService.get('RESOLVER_DOMAIN')}/voc/?show=linktypes`,
       };
     });
+
+    // Include the UNTP link type namespace as a built-in entry
+    identifierLinkTypes.push({
+      namespace: 'https://test.uncefact.org/untp/linkType#',
+      prefix: 'untp:',
+      profile: 'https://untp.unece.org/docs/specification/IdentityResolver',
+    });
+
+    return identifierLinkTypes;
   }
 
   // Get the content of the JSON file

--- a/app/src/modules/link-registration/link-management.service.ts
+++ b/app/src/modules/link-registration/link-management.service.ts
@@ -117,7 +117,12 @@ export class LinkManagementService {
       active: doc.active,
       responses: activeResponses as Response[],
     };
-    doc.linkset = constructLinkSetJson(payload, aiCode, attrs);
+    doc.linkset = constructLinkSetJson(
+      payload,
+      aiCode,
+      attrs,
+      doc.versionHistory,
+    );
     doc.linkHeaderText = constructHTTPLink(payload, aiCode, attrs);
   }
 

--- a/app/src/modules/link-registration/link-registration.service.ts
+++ b/app/src/modules/link-registration/link-registration.service.ts
@@ -100,10 +100,12 @@ export class LinkRegistrationService {
       ...payload,
       responses: payload.responses.filter((r) => r.active !== false),
     };
-    const linkset = constructLinkSetJson(activePayload, aiCode, {
-      resolverDomain,
-      linkTypeVocDomain,
-    });
+    const linkset = constructLinkSetJson(
+      activePayload,
+      aiCode,
+      { resolverDomain, linkTypeVocDomain },
+      versionHistory,
+    );
     const linkHeaderText = constructHTTPLink(activePayload, aiCode, {
       resolverDomain,
       linkTypeVocDomain,


### PR DESCRIPTION
This PR adds UNTP linkset construction logic and predecessor-version support on top of the data model from PR #68. UNTP properties (`encryptionMethod`, `accessRole`, `method`) appear on link targets in the JSON linkset when present and are omitted when absent. Predecessor-version entries are placed inside each link type array with `rel: ["predecessor-version"]`, matching the UNTP Identity Resolver specification.

## Changes

- **Linkset construction** (`link-set.utils.ts`): conditionally includes UNTP properties on link targets; builds predecessor-version entries inside link type arrays from `versionHistory[].changes[].previousTargetUrl` with historical metadata fallback
- **Predecessor-version placement**: entries appear inside the same link type array as the current version, marked with `rel: ["predecessor-version"]` per the UNTP spec
- **UNTP in supportedLinkType**: the `.well-known/resolver` endpoint now includes the UNTP link type namespace (`https://test.uncefact.org/untp/linkType#`) as a built-in entry
- **`method` field**: changed from `string[]` to `string` (single HTTP method, not an array)
- **Services**: both `LinkRegistrationService` and `LinkManagementService` pass `versionHistory` to linkset construction
- **11 unit tests** covering UNTP property inclusion/exclusion, predecessor-version generation, multiple predecessors, historical metadata preference
- **5 E2E tests** covering registration with UNTP properties, listing, resolution, update, and predecessor-version after targetUrl change

## Test plan
- [x] 324 unit tests pass
- [x] TypeScript compilation clean
- [x] Prettier formatting clean
- [x] Manual verification: predecessor-version entries appear inside link type arrays with `rel: ["predecessor-version"]`
- [x] Manual verification: UNTP namespace appears in `.well-known/resolver` supportedLinkType