### PR TITLE
fix(ci): remove push condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR removes the push trigger from the release workflow so that merges to master no longer create a release and inadvertently overwrite Docker images tagged with the version defined in version.json.