### PR TITLE
fix(link-registration): normalise deprecated itemDescription alias to description

### DIFF
--- a/app/src/modules/link-registration/backwards-compat.spec.ts
+++ b/app/src/modules/link-registration/backwards-compat.spec.ts
@@ -8,10 +8,17 @@ import { LinkRegistrationService } from './link-registration.service';
 import { normaliseDocument } from './utils/version.utils';
 
 /**
- * Backwards-compatibility tests for deprecated itemDescription field.
- * TODO(v3.0): Remove when itemDescription support is dropped.
+ * Backwards-compatibility tests for the deprecated itemDescription field.
+ *
+ * The normalisation from itemDescription -> description on inbound requests
+ * is performed by ItemDescriptionNormalisationMiddleware (covered separately
+ * in middleware/item-description-normalisation.middleware.spec.ts). These
+ * tests cover the remaining surfaces:
+ *   - the request-path pipe that strips the leftover itemDescription field,
+ *   - the storage read path that normalises legacy stored documents,
+ *   - the DTO's description constraint (still required post-normalisation).
  */
-describe('itemDescription backwards compatibility (remove in v3.0)', () => {
+describe('itemDescription backwards compatibility', () => {
   let pipe: LinkRegistrationTransformPipe;
 
   const mockIdentifierManagementService = {
@@ -80,53 +87,31 @@ describe('itemDescription backwards compatibility (remove in v3.0)', () => {
     );
   });
 
-  describe('Transform pipe', () => {
-    it('should remove itemDescription from the DTO when only itemDescription is provided', async () => {
+  describe('LinkRegistrationTransformPipe', () => {
+    it('strips the leftover itemDescription field from the DTO', async () => {
+      // By the time the request reaches this pipe the middleware has already
+      // copied itemDescription into description. The pipe is responsible for
+      // removing the deprecated field so it does not reach storage.
       const input = {
         namespace: 'testNamespace',
         identificationKeyType: 'test',
         identificationKey: 'testKey',
-        description: 'Copied from itemDescription by @Transform',
+        description: 'Canonical description',
         qualifierPath: '/',
         active: false,
         responses: baseResponses,
-        itemDescription: 'Old field value',
+        itemDescription: 'Legacy value',
       } as CreateLinkRegistrationDto & { itemDescription?: string };
 
       const result = await pipe.transform(input);
 
       expect((result as any).itemDescription).toBeUndefined();
-    });
-
-    it('should prefer description over itemDescription when both are provided', async () => {
-      // The @Transform on the DTO resolves description ?? itemDescription before the pipe runs.
-      // We simulate the post-transform state: description already holds the winning value.
-      const plain = {
-        namespace: 'testNamespace',
-        identificationKeyType: 'test',
-        identificationKey: 'testKey',
-        description: 'Canonical description',
-        itemDescription: 'Legacy value',
-        qualifierPath: '/',
-        active: false,
-        responses: baseResponses,
-      };
-
-      const dto = plainToClass(CreateLinkRegistrationDto, plain);
-
-      // After class-transformer runs the @Transform, description should be 'Canonical description'
-      // because it uses ?? (nullish coalescing): description is non-null so itemDescription is ignored.
-      expect(dto.description).toBe('Canonical description');
-
-      // The pipe should then strip the leftover itemDescription field.
-      const result = await pipe.transform(dto);
-      expect((result as any).itemDescription).toBeUndefined();
-      expect((result as any).description).toBe('Canonical description');
+      expect(result.description).toBe('Canonical description');
     });
   });
 
   describe('normaliseDocument (storage read path)', () => {
-    it('should convert itemDescription to description when reading a stored document', () => {
+    it('converts itemDescription to description when reading a stored document', () => {
       const doc = {
         itemDescription: 'Legacy stored value',
         responses: [],
@@ -138,7 +123,7 @@ describe('itemDescription backwards compatibility (remove in v3.0)', () => {
       expect((result as any).itemDescription).toBeUndefined();
     });
 
-    it('should not overwrite description with itemDescription when both are present', () => {
+    it('does not overwrite description with itemDescription when both are present', () => {
       const doc = {
         description: 'Current description',
         itemDescription: 'Old legacy value',
@@ -153,12 +138,13 @@ describe('itemDescription backwards compatibility (remove in v3.0)', () => {
   });
 
   describe('DTO validation', () => {
-    it('should fail validation when neither description nor itemDescription is provided', async () => {
+    it('fails validation when description is not populated', async () => {
+      // If the middleware has not copied itemDescription across (e.g. because
+      // neither field was provided) the DTO must still reject the request.
       const plain = {
         namespace: 'testNamespace',
         identificationKeyType: 'test',
         identificationKey: 'testKey',
-        // description omitted, itemDescription omitted
         qualifierPath: '/',
         active: false,
         responses: baseResponses,
@@ -171,24 +157,20 @@ describe('itemDescription backwards compatibility (remove in v3.0)', () => {
       expect(descriptionError).toBeDefined();
     });
 
-    it('should pass validation when description is populated (as the framework does via @Transform from itemDescription)', async () => {
-      // The NestJS ValidationPipe with transform:true fires the @Transform at the HTTP layer,
-      // copying itemDescription → description when only itemDescription is present.
-      // We simulate the post-transform state here: description already holds the copied value.
+    it('passes validation once description is populated (post-middleware state)', async () => {
+      // Simulates the state after ItemDescriptionNormalisationMiddleware has
+      // copied the legacy itemDescription value onto description.
       const plain = {
         namespace: 'testNamespace',
         identificationKeyType: 'test',
         identificationKey: 'testKey',
-        description: 'Legacy value only', // as if copied from itemDescription by the framework
+        description: 'Legacy value only',
         qualifierPath: '/',
         active: false,
         responses: baseResponses,
       };
 
       const dto = plainToClass(CreateLinkRegistrationDto, plain);
-
-      expect(dto.description).toBe('Legacy value only');
-
       const errors = await validate(dto);
       const descriptionError = errors.find((e) => e.property === 'description');
       expect(descriptionError).toBeUndefined();

--- a/app/src/modules/link-registration/dto/link-registration.dto.ts
+++ b/app/src/modules/link-registration/dto/link-registration.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type, Transform } from 'class-transformer';
+import { Type } from 'class-transformer';
 import {
   ArrayNotEmpty,
   IsArray,
@@ -182,9 +182,6 @@ export class CreateLinkRegistrationDto {
   @ApiProperty({
     description: 'Description of the item being identified',
     example: 'Product description',
-  })
-  @Transform(({ obj }) => obj.description ?? obj.itemDescription, {
-    toClassOnly: true,
   })
   @IsString()
   @IsNotEmpty()

--- a/app/src/modules/link-registration/link-registration.module.ts
+++ b/app/src/modules/link-registration/link-registration.module.ts
@@ -1,4 +1,9 @@
-import { Module } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { ConfigModule } from '@nestjs/config';
 import { LinkRegistrationController } from './link-registration.controller';
@@ -6,10 +11,17 @@ import { LinkRegistrationService } from './link-registration.service';
 import { LinkManagementController } from './link-management.controller';
 import { LinkManagementService } from './link-management.service';
 import { IdentifierManagementModule } from '../identifier-management/identifier-management.module';
+import { ItemDescriptionNormalisationMiddleware } from './middleware/item-description-normalisation.middleware';
 
 @Module({
   controllers: [LinkRegistrationController, LinkManagementController],
   providers: [LinkRegistrationService, LinkManagementService],
   imports: [ConfigModule, IdentifierManagementModule, HttpModule],
 })
-export class LinkRegistrationModule {}
+export class LinkRegistrationModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer
+      .apply(ItemDescriptionNormalisationMiddleware)
+      .forRoutes({ path: 'resolver', method: RequestMethod.POST });
+  }
+}

--- a/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.spec.ts
+++ b/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.spec.ts
@@ -1,0 +1,64 @@
+import { Request, Response } from 'express';
+import { ItemDescriptionNormalisationMiddleware } from './item-description-normalisation.middleware';
+
+describe('ItemDescriptionNormalisationMiddleware', () => {
+  let middleware: ItemDescriptionNormalisationMiddleware;
+  let next: jest.Mock;
+
+  const run = (body: unknown) => {
+    const req = { body } as Request;
+    middleware.use(req, {} as Response, next);
+    return req.body;
+  };
+
+  beforeEach(() => {
+    middleware = new ItemDescriptionNormalisationMiddleware();
+    next = jest.fn();
+  });
+
+  it('copies itemDescription onto description when description is absent', () => {
+    const body = run({ itemDescription: 'Legacy value' });
+    expect(body).toEqual({
+      description: 'Legacy value',
+      itemDescription: 'Legacy value',
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('copies itemDescription onto description when description is null', () => {
+    const body = run({ description: null, itemDescription: 'Legacy value' });
+    expect((body as any).description).toBe('Legacy value');
+  });
+
+  it('preserves description when both fields are provided', () => {
+    const body = run({
+      description: 'Canonical',
+      itemDescription: 'Legacy value',
+    });
+    expect((body as any).description).toBe('Canonical');
+    expect((body as any).itemDescription).toBe('Legacy value');
+  });
+
+  it('leaves the body untouched when itemDescription is absent', () => {
+    const body = run({ description: 'Canonical' });
+    expect(body).toEqual({ description: 'Canonical' });
+  });
+
+  it('leaves the body untouched when itemDescription is null', () => {
+    const body = run({ itemDescription: null });
+    expect(body).toEqual({ itemDescription: null });
+  });
+
+  it('calls next exactly once when the body is missing', () => {
+    const req = {} as Request;
+    middleware.use(req, {} as Response, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls next exactly once when the body is not an object', () => {
+    const req = { body: 'not-an-object' } as unknown as Request;
+    middleware.use(req, {} as Response, next);
+    expect(req.body).toBe('not-an-object');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.spec.ts
+++ b/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.spec.ts
@@ -39,6 +39,15 @@ describe('ItemDescriptionNormalisationMiddleware', () => {
     expect((body as any).itemDescription).toBe('Legacy value');
   });
 
+  it('does not overwrite an empty-string description with itemDescription', () => {
+    // Empty string is an explicit caller-supplied value, not a missing field.
+    // Downstream @IsNotEmpty validation will reject it with a clear error,
+    // which is preferable to silently replacing it with the deprecated alias.
+    const body = run({ description: '', itemDescription: 'Legacy value' });
+    expect((body as any).description).toBe('');
+    expect((body as any).itemDescription).toBe('Legacy value');
+  });
+
   it('leaves the body untouched when itemDescription is absent', () => {
     const body = run({ description: 'Canonical' });
     expect(body).toEqual({ description: 'Canonical' });

--- a/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.ts
+++ b/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.ts
@@ -1,0 +1,23 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Normalises the deprecated `itemDescription` alias on link registration
+ * request bodies before the global ValidationPipe runs. If the payload
+ * sets `itemDescription` but omits `description`, the value is copied
+ * onto `description`. When both are provided, `description` wins. The
+ * alias is left in place so the ValidationPipe (with `whitelist: true`)
+ * strips it from the resulting DTO.
+ */
+@Injectable()
+export class ItemDescriptionNormalisationMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction): void {
+    const body = req.body as Record<string, unknown> | undefined;
+    if (body && typeof body === 'object') {
+      if (body.description == null && body.itemDescription != null) {
+        body.description = body.itemDescription;
+      }
+    }
+    next();
+  }
+}

--- a/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.ts
+++ b/app/src/modules/link-registration/middleware/item-description-normalisation.middleware.ts
@@ -6,8 +6,8 @@ import { NextFunction, Request, Response } from 'express';
  * request bodies before the global ValidationPipe runs. If the payload
  * sets `itemDescription` but omits `description`, the value is copied
  * onto `description`. When both are provided, `description` wins. The
- * alias is left in place so the ValidationPipe (with `whitelist: true`)
- * strips it from the resulting DTO.
+ * alias is left on the body; the route's `ValidationPipe({ whitelist: true })`
+ * and `LinkRegistrationTransformPipe` together strip it before persistence.
  */
 @Injectable()
 export class ItemDescriptionNormalisationMiddleware implements NestMiddleware {

--- a/app/src/modules/link-registration/pipes/link-registration-transform.pipe.ts
+++ b/app/src/modules/link-registration/pipes/link-registration-transform.pipe.ts
@@ -27,7 +27,7 @@ export class LinkRegistrationTransformPipe
   async transform(
     value: CreateLinkRegistrationDto,
   ): Promise<CreateLinkRegistrationDto> {
-    // Remove deprecated itemDescription (already normalised to description by @Transform on DTO)
+    // Remove deprecated itemDescription (already copied to description by ItemDescriptionNormalisationMiddleware).
     delete (value as any).itemDescription;
 
     const identifier = await this.identifierManagementService.getIdentifier(

--- a/app/test/link-registration/item-description-backwards-compat.e2e-spec.ts
+++ b/app/test/link-registration/item-description-backwards-compat.e2e-spec.ts
@@ -121,6 +121,7 @@ describe('LinkRegistration — itemDescription backwards compatibility (e2e)', (
 
     const body = JSON.parse(res.text);
     expect(body.linkset[0].description).toBe(canonical);
+    expect(body.linkset[0].itemDescription).toBeUndefined();
   });
 
   it('rejects a registration that omits both description and itemDescription', async () => {

--- a/app/test/link-registration/item-description-backwards-compat.e2e-spec.ts
+++ b/app/test/link-registration/item-description-backwards-compat.e2e-spec.ts
@@ -1,0 +1,142 @@
+import { HttpStatus } from '@nestjs/common';
+import request from 'supertest';
+import { APP_ROUTE_PREFIX } from '../../src/common/utils/config.utils';
+import { IdentifierDto } from 'src/modules/identifier-management/dto/identifier.dto';
+
+const baseUrl = process.env.API_BASE_URL + APP_ROUTE_PREFIX;
+const environment = process.env.NODE_ENV;
+const apiKey = process.env.API_KEY;
+
+const namespace = `e2e-${environment}-mock-item-description`;
+
+const identificationKeyType = 'gtin';
+const qualifierPath = '/';
+
+const identifierDto = (): IdentifierDto => ({
+  namespace,
+  namespaceProfile: '',
+  namespaceURI: '',
+  applicationIdentifiers: [
+    {
+      ai: '01',
+      shortcode: 'gtin',
+      type: 'I',
+      title: 'Global Trade Item Number (GTIN)',
+      label: 'GTIN',
+      regex: '(\\d{12,14}|\\d{8})',
+      qualifiers: [],
+    },
+  ],
+});
+
+const baseResponse = {
+  defaultLinkType: true,
+  defaultMimeType: true,
+  defaultIanaLanguage: true,
+  defaultContext: true,
+  fwqs: false,
+  active: true,
+  linkType: 'gs1:certificationInfo',
+  ianaLanguage: 'en',
+  context: 'au',
+  title: 'Certification Information',
+  targetUrl: 'https://example.com',
+  mimeType: 'application/json',
+};
+
+const headers = {
+  Accept: 'application/json',
+  Authorization: `Bearer ${apiKey}`,
+};
+
+describe('LinkRegistration — itemDescription backwards compatibility (e2e)', () => {
+  beforeAll(async () => {
+    await request(baseUrl)
+      .post('/identifiers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .send(identifierDto())
+      .expect(HttpStatus.OK);
+  });
+
+  afterAll(async () => {
+    await request(baseUrl)
+      .delete('/identifiers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .query({ namespace })
+      .expect(HttpStatus.OK);
+  });
+
+  it('accepts a registration when only itemDescription is provided and stores it as description', async () => {
+    const identificationKey = '10000000000017';
+    const legacyDescription = 'Legacy item description only';
+
+    await request(baseUrl)
+      .post('/resolver')
+      .send({
+        namespace,
+        identificationKeyType,
+        identificationKey,
+        itemDescription: legacyDescription,
+        qualifierPath,
+        active: true,
+        responses: [baseResponse],
+      })
+      .set(headers)
+      .expect(HttpStatus.CREATED)
+      .expect({ message: 'Link resolver registered successfully' });
+
+    const res = await request(baseUrl)
+      .get(`/${namespace}/${identificationKeyType}/${identificationKey}`)
+      .set('Accept', 'application/linkset+json')
+      .expect(200);
+
+    const body = JSON.parse(res.text);
+    expect(body.linkset[0].description).toBe(legacyDescription);
+  });
+
+  it('prefers description over itemDescription when both are provided', async () => {
+    const identificationKey = '10000000000024';
+    const canonical = 'Canonical description';
+    const legacy = 'Legacy item description';
+
+    await request(baseUrl)
+      .post('/resolver')
+      .send({
+        namespace,
+        identificationKeyType,
+        identificationKey,
+        description: canonical,
+        itemDescription: legacy,
+        qualifierPath,
+        active: true,
+        responses: [baseResponse],
+      })
+      .set(headers)
+      .expect(HttpStatus.CREATED);
+
+    const res = await request(baseUrl)
+      .get(`/${namespace}/${identificationKeyType}/${identificationKey}`)
+      .set('Accept', 'application/linkset+json')
+      .expect(200);
+
+    const body = JSON.parse(res.text);
+    expect(body.linkset[0].description).toBe(canonical);
+  });
+
+  it('rejects a registration that omits both description and itemDescription', async () => {
+    const identificationKey = '10000000000031';
+
+    await request(baseUrl)
+      .post('/resolver')
+      .send({
+        namespace,
+        identificationKeyType,
+        identificationKey,
+        qualifierPath,
+        active: true,
+        responses: [baseResponse],
+      })
+      .set(headers)
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+});


### PR DESCRIPTION
This PR restores the backwards-compatibility behaviour promised by the v3 migration guide. POST /resolver now accepts `itemDescription` as a deprecated alias for `description`: when the request omits `description` but supplies `itemDescription`, the value is copied across before validation runs. When both are provided, `description` wins.

The fix is a small `ItemDescriptionNormalisationMiddleware` mounted on `POST /resolver`. A class-transformer `@Transform` on the DTO was the original intent, but it never fired because class-transformer only iterates keys present on the plain object, so `description` stayed undefined and the global `ValidationPipe` rejected the request with a 400. A middleware runs before the global pipe and does the copy on `req.body` directly.

Validated against a local test deployment; the new e2e spec at `app/test/link-registration/item-description-backwards-compat.e2e-spec.ts` exercises all three documented scenarios against the running server and confirms the persisted `description` value can be read back via the resolver.

Closes #95

## Test plan
- [x] Registering with only `itemDescription` succeeds and the value is retrievable as `description`
- [x] Registering with both `description` and `itemDescription` keeps `description` and strips the alias
- [x] Registering with neither field returns 400
- [x] Empty-string `description` is not silently overwritten by `itemDescription`
- [x] Middleware handles missing or non-object request bodies without throwing
- [x] Full unit suite passes (45 suites)
- [x] Full e2e suite passes (10 suites)