### PR TITLE
fix(link-registration): remove invalid type arg from 500 decorator

### DIFF
--- a/app/src/modules/link-registration/link-registration.controller.spec.ts
+++ b/app/src/modules/link-registration/link-registration.controller.spec.ts
@@ -2,6 +2,7 @@ import { I18nService } from 'nestjs-i18n';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpModule } from '@nestjs/axios';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { LinkRegistrationController } from './link-registration.controller';
 import { LinkRegistrationService } from './link-registration.service';
 import { CreateLinkRegistrationDto } from './dto/link-registration.dto';
@@ -11,10 +12,11 @@ import { IdentifierManagementService } from '../identifier-management/identifier
 describe('LinkRegistrationController', () => {
   let controller: LinkRegistrationController;
   let linkRegistrationService: LinkRegistrationService;
+  let module: TestingModule;
 
   beforeEach(async () => {
     // Create a testing module
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       imports: [RepositoryModule, ConfigModule, HttpModule],
       controllers: [LinkRegistrationController],
       providers: [
@@ -58,6 +60,23 @@ describe('LinkRegistrationController', () => {
   it('should be defined', () => {
     // Assert that the controller is defined
     expect(controller).toBeDefined();
+  });
+
+  describe('OpenAPI document', () => {
+    it('does not register a schema with an empty name', async () => {
+      const app = module.createNestApplication();
+      await app.init();
+
+      const document = SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().setTitle('test').setVersion('test').build(),
+      );
+
+      const schemaNames = Object.keys(document.components?.schemas ?? {});
+      expect(schemaNames).not.toContain('');
+
+      await app.close();
+    });
   });
 
   describe('create', () => {

--- a/app/src/modules/link-registration/link-registration.controller.ts
+++ b/app/src/modules/link-registration/link-registration.controller.ts
@@ -54,7 +54,6 @@ export class LinkRegistrationController {
   @ApiInternalServerErrorResponse({
     status: 500,
     description: 'Internal Server Error',
-    type: ApiInternalServerErrorResponse,
   })
   @UsePipes(
     new ValidationPipe({ whitelist: true }), // ignore extra fields


### PR DESCRIPTION
This PR removes a bogus `type: ApiInternalServerErrorResponse` argument from
the 500 response decorator on `POST /resolver`, eliminating the empty-named
schema component that NestJS Swagger was emitting into the generated
`openapi.json`. The decorator factory was being passed where a class
reference was expected; removing it brings the 500 response in line with
the convention already used by the sister `LinkManagementController`.

A regression test boots the controller, calls `SwaggerModule.createDocument`,
and asserts the generated schemas object has no empty-named key.

Closes #103

## Test plan
- [x] Regression test fails when the bogus `type:` argument is restored, passes when removed
- [x] Generated OpenAPI document no longer contains an empty-named schema
- [x] Existing 500 response behaviour is unchanged (no DTO ever rendered correctly for it)
- [x] Full unit suite passes (45 suites, 436 tests)