### PR TITLE
feat(link-registration): add public flag to link target variants

### DIFF
--- a/app/src/modules/link-registration/dto/link-management.dto.ts
+++ b/app/src/modules/link-registration/dto/link-management.dto.ts
@@ -10,6 +10,7 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { OptionalMimeTypeProperty } from './mime-type-property.decorator';
+import { PublicProperty } from './public-property.decorator';
 import {
   EncryptionMethod,
   ENCRYPTION_METHODS,
@@ -326,4 +327,7 @@ export class UpdateLinkDto {
   @IsOptional()
   @IsString()
   method?: string;
+
+  @PublicProperty()
+  public?: boolean;
 }

--- a/app/src/modules/link-registration/dto/link-registration.dto.ts
+++ b/app/src/modules/link-registration/dto/link-registration.dto.ts
@@ -13,6 +13,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { MimeTypeProperty } from './mime-type-property.decorator';
+import { PublicProperty } from './public-property.decorator';
 import {
   EncryptionMethod,
   ENCRYPTION_METHODS,
@@ -146,6 +147,9 @@ export class Response {
   @IsOptional()
   @IsString()
   method?: string;
+
+  @PublicProperty()
+  public?: boolean;
 }
 
 export class CreateLinkRegistrationDto {
@@ -226,6 +230,7 @@ export class CreateLinkRegistrationDto {
         encryptionMethod: 'none',
         accessRole: ['untp:accessRole#Anonymous'],
         method: 'POST',
+        public: true,
       },
     ],
   })

--- a/app/src/modules/link-registration/dto/public-property.decorator.ts
+++ b/app/src/modules/link-registration/dto/public-property.decorator.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+const PUBLIC_DESCRIPTION =
+  'Whether the URL itself is safe to publish in a public directory. ' +
+  'Distinct from `accessRole` and `encryptionMethod`, which govern who ' +
+  'may retrieve or decrypt the resource at that URL. A link may be ' +
+  '`public: true` while still requiring an authorised role to fetch ' +
+  'the content.';
+
+/**
+ * Decorates the optional `public: boolean` field on link target DTOs.
+ * Bundles the OpenAPI metadata and the boolean validator so the
+ * description and example stay consistent across every DTO that
+ * exposes the field.
+ */
+export const PublicProperty = () =>
+  applyDecorators(
+    ApiPropertyOptional({
+      description: PUBLIC_DESCRIPTION,
+      example: true,
+    }),
+    IsOptional(),
+    IsBoolean(),
+  );

--- a/app/src/modules/link-registration/interfaces/link-set.interface.ts
+++ b/app/src/modules/link-registration/interfaces/link-set.interface.ts
@@ -15,6 +15,16 @@ export type LinkTargetObject = {
   accessRole?: string[];
   method?: string;
   rel?: string[];
+  /**
+   * Whether the URL itself is safe to publish in a public directory.
+   * Distinct from `accessRole` and `encryptionMethod`, which govern who
+   * may retrieve or decrypt the *content* at that URL. A target may be
+   * `public: true` while still requiring an authorised role to fetch
+   * the resource.
+   *
+   * @see https://untp.unece.org/docs/specification/IdentityResolver UNTP Identity Resolver Linkset Schema
+   */
+  public?: boolean;
 };
 
 export type InternationalizedTargetAttributes = {
@@ -44,6 +54,8 @@ export interface LinkSetResponseInput {
   encryptionMethod?: string;
   accessRole?: string[];
   method?: string;
+  /** @see {@link LinkTargetObject.public} */
+  public?: boolean;
   linkId?: string;
 }
 

--- a/app/src/modules/link-registration/link-management.service.spec.ts
+++ b/app/src/modules/link-registration/link-management.service.spec.ts
@@ -571,6 +571,26 @@ describe('LinkManagementService', () => {
       ).rejects.toThrow('conflict');
     });
 
+    it.each([true, false])(
+      'should persist `public: %s` through the generic update loop',
+      async (publicValue) => {
+        repositoryProvider.one.mockImplementation((id: string) =>
+          id.includes('_index')
+            ? Promise.resolve(mockIndex as any)
+            : Promise.resolve(JSON.parse(JSON.stringify(mockDocument)) as any),
+        );
+        repositoryProvider.save.mockResolvedValue(undefined);
+
+        await service.updateLink('abc12345', { public: publicValue });
+
+        const savedDoc = repositoryProvider.save.mock.calls[0][0];
+        const updatedResponse = savedDoc.responses.find(
+          (r) => r.linkId === 'abc12345',
+        );
+        expect(updatedResponse.public).toBe(publicValue);
+      },
+    );
+
     it('should record previousMimeType in version history when mimeType changes', async () => {
       repositoryProvider.one.mockImplementation((id: string) =>
         id.includes('_index')

--- a/app/src/modules/link-registration/utils/link-set.utils.spec.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.spec.ts
@@ -194,6 +194,7 @@ describe('Link Set Utils', () => {
               'untp:accessRole#Regulator',
             ],
             method: 'POST',
+            public: true,
           },
         ],
       };
@@ -210,7 +211,45 @@ describe('Link Set Utils', () => {
         'untp:accessRole#Regulator',
       ]);
       expect(linkTargets[0].method).toBe('POST');
+      expect(linkTargets[0].public).toBe(true);
     });
+
+    it.each([true, false])(
+      'should emit `public: %s` when explicitly set on response',
+      (publicValue) => {
+        const uri: LinkSetInput = {
+          namespace: 'idr',
+          identificationKeyType: 'test',
+          identificationKey: '12345',
+          description: 'example',
+          qualifierPath: '/',
+          active: true,
+          responses: [
+            {
+              linkType: 'gs1:certificationInfo',
+              targetUrl: 'https://example.com/cert',
+              title: 'Certification',
+              mimeType: 'application/json',
+              ianaLanguage: 'en',
+              context: 'us',
+              active: true,
+              fwqs: false,
+              defaultLinkType: true,
+              defaultIanaLanguage: true,
+              defaultContext: true,
+              defaultMimeType: true,
+              public: publicValue,
+            },
+          ],
+        };
+
+        const result = constructLinkSetJson(uri, '01', attrs);
+        const linkTargets =
+          result['https://linktypevoc.example.com/voc/certificationInfo'];
+
+        expect(linkTargets[0].public).toBe(publicValue);
+      },
+    );
 
     it('should omit UNTP properties when not present on response', () => {
       const uri: LinkSetInput = {
@@ -247,6 +286,7 @@ describe('Link Set Utils', () => {
       expect(linkTargets[0]).not.toHaveProperty('encryptionMethod');
       expect(linkTargets[0]).not.toHaveProperty('accessRole');
       expect(linkTargets[0]).not.toHaveProperty('method');
+      expect(linkTargets[0]).not.toHaveProperty('public');
     });
 
     it('should include predecessor-version entries from version history', () => {

--- a/app/src/modules/link-registration/utils/link-set.utils.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.ts
@@ -127,6 +127,9 @@ const constructLinkTargetObjects = (
           if (firstGroupedResponse.method) {
             linkTarget.method = firstGroupedResponse.method;
           }
+          if (firstGroupedResponse.public !== undefined) {
+            linkTarget.public = firstGroupedResponse.public;
+          }
 
           acc[key].push(linkTarget);
         },

--- a/app/src/modules/link-resolution/interfaces/uri.interface.ts
+++ b/app/src/modules/link-resolution/interfaces/uri.interface.ts
@@ -20,6 +20,8 @@ export interface LinkResponse {
   encryptionMethod?: EncryptionMethod;
   accessRole?: string[];
   method?: string;
+  /** @see {@link LinkTargetObject.public} from `../../link-registration/interfaces/link-set.interface` */
+  public?: boolean;
 }
 
 export interface LinkChange {


### PR DESCRIPTION
This PR adds the optional `public: boolean` field to link target variants
on the `Response` DTO (POST `/resolver`) and `UpdateLinkDto` (PUT
`/resolver/links/:linkId`), with persistence and linkset emission wired
end-to-end. The field indicates whether the URL itself is safe to publish
in a public directory, and is intentionally distinct from `accessRole`
and `encryptionMethod`, which govern who may retrieve or decrypt the
resource at that URL. A link may be `public: true` while still requiring
an authorised role to fetch the content.

DTO decoration is centralised in a `@PublicProperty()` composite
decorator so the description and example stay consistent across DTOs.
The linkset builder emits `public` only when `firstGroupedResponse.public !== undefined`,
so an explicit `public: false` round-trips through the linkset distinct
from "not set". No service code change was required: the existing
generic update loop in `link-management.service.ts:updateLink` picks up
the field automatically, and a new persistence-loop test guards against
that being replaced with a hardcoded allowlist.

Closes #100

## Test plan
- [x] Linkset construction emits `public: true` when set on the source response
- [x] Linkset construction emits `public: false` when explicitly set (not skipped as falsy)
- [x] Linkset construction omits `public` when absent from the source response
- [x] `updateLink({ public: true | false })` persists the field through the generic update loop
- [x] OpenAPI schema documents `public` on `Response` and `UpdateLinkDto` with the same description
- [x] Full unit suite passes (45 suites, 439 tests)