### PR TITLE
feat(link-registration): add rel field to link target variants

### DIFF
--- a/app/src/modules/link-registration/dto/link-management.dto.ts
+++ b/app/src/modules/link-registration/dto/link-management.dto.ts
@@ -17,6 +17,7 @@ import {
   UntpAccessRole,
   UNTP_ACCESS_ROLES,
 } from '../constants/untp-enums';
+import { RelProperty } from './rel-property.decorator';
 
 /**
  * Query DTO for listing all links for an identifier.
@@ -330,4 +331,7 @@ export class UpdateLinkDto {
 
   @PublicProperty()
   public?: boolean;
+
+  @RelProperty()
+  rel?: string[];
 }

--- a/app/src/modules/link-registration/dto/link-registration.dto.ts
+++ b/app/src/modules/link-registration/dto/link-registration.dto.ts
@@ -20,6 +20,7 @@ import {
   UntpAccessRole,
   UNTP_ACCESS_ROLES,
 } from '../constants/untp-enums';
+import { RelProperty } from './rel-property.decorator';
 
 export class Response {
   @ApiProperty({
@@ -150,6 +151,9 @@ export class Response {
 
   @PublicProperty()
   public?: boolean;
+
+  @RelProperty()
+  rel?: string[];
 }
 
 export class CreateLinkRegistrationDto {
@@ -231,6 +235,7 @@ export class CreateLinkRegistrationDto {
         accessRole: ['untp:accessRole#Anonymous'],
         method: 'POST',
         public: true,
+        rel: ['edit'],
       },
     ],
   })

--- a/app/src/modules/link-registration/dto/rel-property.decorator.ts
+++ b/app/src/modules/link-registration/dto/rel-property.decorator.ts
@@ -1,0 +1,48 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+/**
+ * Link relation values the server emits itself and reserves from
+ * publisher input. Publisher-set rel arrays are filtered to strip
+ * these values so server semantics cannot be overwritten or forged
+ * via the input path.
+ */
+const SERVER_RESERVED_REL_VALUES: ReadonlyArray<string> = [
+  'predecessor-version',
+];
+
+const REL_DESCRIPTION =
+  'Additional link relation types qualifying this link beyond its ' +
+  'primary linkType (e.g. `edit`, `latest-version`). Treated as ' +
+  'opaque strings; values are not validated against the IANA link ' +
+  'relation registry. Server-reserved values (`predecessor-version`) ' +
+  'are silently stripped from the input.';
+
+/**
+ * Decorates the optional `rel: string[]` field on link target DTOs.
+ * Bundles the OpenAPI metadata, the array-of-strings validator, and
+ * a `@Transform` that strips server-reserved rel values so the
+ * description, example, and filtering rule stay consistent across
+ * every DTO that exposes the field.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8288 RFC 8288 Web Linking (defines `rel`)
+ * @see https://www.rfc-editor.org/rfc/rfc9264 RFC 9264 Linkset (defines the linkset target format)
+ */
+export const RelProperty = () =>
+  applyDecorators(
+    ApiPropertyOptional({
+      description: REL_DESCRIPTION,
+      example: ['edit'],
+      type: [String],
+    }),
+    Transform(({ value }) =>
+      Array.isArray(value)
+        ? value.filter((v) => !SERVER_RESERVED_REL_VALUES.includes(v))
+        : value,
+    ),
+    IsOptional(),
+    IsArray(),
+    IsString({ each: true }),
+  );

--- a/app/src/modules/link-registration/dto/rel-validation.spec.ts
+++ b/app/src/modules/link-registration/dto/rel-validation.spec.ts
@@ -1,0 +1,88 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { Response } from './link-registration.dto';
+import { UpdateLinkDto } from './link-management.dto';
+
+const baseResponse = {
+  defaultLinkType: true,
+  defaultMimeType: true,
+  defaultIanaLanguage: true,
+  defaultContext: true,
+  fwqs: false,
+  active: true,
+  linkType: 'example-identifier-scheme:certificationInfo',
+  ianaLanguage: 'en',
+  context: 'au',
+  title: 'Certification Information',
+  targetUrl: 'https://example.com',
+  mimeType: 'application/json',
+};
+
+describe('rel validation', () => {
+  describe('Response (POST /resolver)', () => {
+    it('accepts an opaque rel value', async () => {
+      const dto = plainToInstance(Response, {
+        ...baseResponse,
+        rel: ['edit'],
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'rel')).toBeUndefined();
+      expect(dto.rel).toEqual(['edit']);
+    });
+
+    it('strips server-reserved `predecessor-version` from input', async () => {
+      const dto = plainToInstance(Response, {
+        ...baseResponse,
+        rel: ['edit', 'predecessor-version', 'latest-version'],
+      });
+      expect(dto.rel).toEqual(['edit', 'latest-version']);
+    });
+
+    it('reduces to an empty array when only `predecessor-version` is supplied', async () => {
+      const dto = plainToInstance(Response, {
+        ...baseResponse,
+        rel: ['predecessor-version'],
+      });
+      expect(dto.rel).toEqual([]);
+    });
+
+    it('rejects a non-array rel value', async () => {
+      const dto = plainToInstance(Response, {
+        ...baseResponse,
+        rel: 'edit' as any,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'rel')).toBeDefined();
+    });
+  });
+
+  describe('UpdateLinkDto (PUT /resolver/links/:linkId)', () => {
+    it('accepts an opaque rel value', async () => {
+      const dto = plainToInstance(UpdateLinkDto, { rel: ['edit'] });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'rel')).toBeUndefined();
+      expect(dto.rel).toEqual(['edit']);
+    });
+
+    it('strips server-reserved `predecessor-version` from input', async () => {
+      const dto = plainToInstance(UpdateLinkDto, {
+        rel: ['edit', 'predecessor-version'],
+      });
+      expect(dto.rel).toEqual(['edit']);
+    });
+
+    it('accepts an empty rel array (clears the field)', async () => {
+      const dto = plainToInstance(UpdateLinkDto, { rel: [] });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'rel')).toBeUndefined();
+      expect(dto.rel).toEqual([]);
+    });
+
+    it('accepts rel: null and passes it through (treated as absent at the linkset boundary)', async () => {
+      const dto = plainToInstance(UpdateLinkDto, { rel: null });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'rel')).toBeUndefined();
+      expect(dto.rel).toBeNull();
+    });
+  });
+});

--- a/app/src/modules/link-registration/interfaces/link-set.interface.ts
+++ b/app/src/modules/link-registration/interfaces/link-set.interface.ts
@@ -56,6 +56,7 @@ export interface LinkSetResponseInput {
   method?: string;
   /** @see {@link LinkTargetObject.public} */
   public?: boolean;
+  rel?: string[];
   linkId?: string;
 }
 

--- a/app/src/modules/link-registration/link-management.service.spec.ts
+++ b/app/src/modules/link-registration/link-management.service.spec.ts
@@ -591,6 +591,62 @@ describe('LinkManagementService', () => {
       },
     );
 
+    it('should persist `rel` through the generic update loop', async () => {
+      repositoryProvider.one.mockImplementation((id: string) =>
+        id.includes('_index')
+          ? Promise.resolve(mockIndex as any)
+          : Promise.resolve(JSON.parse(JSON.stringify(mockDocument)) as any),
+      );
+      repositoryProvider.save.mockResolvedValue(undefined);
+
+      await service.updateLink('abc12345', { rel: ['edit', 'latest-version'] });
+
+      const savedDoc = repositoryProvider.save.mock.calls[0][0];
+      const updatedResponse = savedDoc.responses.find(
+        (r) => r.linkId === 'abc12345',
+      );
+      expect(updatedResponse.rel).toEqual(['edit', 'latest-version']);
+    });
+
+    it('should clear `rel` when an empty array is supplied (replace semantics)', async () => {
+      const docWithRel = JSON.parse(JSON.stringify(mockDocument));
+      docWithRel.responses[0].rel = ['edit'];
+      repositoryProvider.one.mockImplementation((id: string) =>
+        id.includes('_index')
+          ? Promise.resolve(mockIndex as any)
+          : Promise.resolve(docWithRel as any),
+      );
+      repositoryProvider.save.mockResolvedValue(undefined);
+
+      await service.updateLink('abc12345', { rel: [] });
+
+      const savedDoc = repositoryProvider.save.mock.calls[0][0];
+      const updatedResponse = savedDoc.responses.find(
+        (r) => r.linkId === 'abc12345',
+      );
+      expect(updatedResponse.rel).toEqual([]);
+    });
+
+    it('should not record any previous* field when only `rel` changes', async () => {
+      repositoryProvider.one.mockImplementation((id: string) =>
+        id.includes('_index')
+          ? Promise.resolve(mockIndex as any)
+          : Promise.resolve(JSON.parse(JSON.stringify(mockDocument)) as any),
+      );
+      repositoryProvider.save.mockResolvedValue(undefined);
+
+      await service.updateLink('abc12345', { rel: ['edit'] });
+
+      const savedDoc = repositoryProvider.save.mock.calls[0][0];
+      const change = savedDoc.versionHistory[0].changes[0];
+      expect(change).toEqual({ linkId: 'abc12345', action: 'updated' });
+      expect(change).not.toHaveProperty('previousTargetUrl');
+      expect(change).not.toHaveProperty('previousLinkType');
+      expect(change).not.toHaveProperty('previousMimeType');
+      expect(change).not.toHaveProperty('previousIanaLanguage');
+      expect(change).not.toHaveProperty('previousContext');
+    });
+
     it('should record previousMimeType in version history when mimeType changes', async () => {
       repositoryProvider.one.mockImplementation((id: string) =>
         id.includes('_index')

--- a/app/src/modules/link-registration/link-registration.controller.ts
+++ b/app/src/modules/link-registration/link-registration.controller.ts
@@ -56,7 +56,7 @@ export class LinkRegistrationController {
     description: 'Internal Server Error',
   })
   @UsePipes(
-    new ValidationPipe({ whitelist: true }), // ignore extra fields
+    new ValidationPipe({ whitelist: true, transform: true }), // strip extras and run @Transform decorators
     IdentifierSetValidationPipe,
     ISO639ValidationPipe,
     Bcp47ValidationPipe,

--- a/app/src/modules/link-registration/utils/link-set.utils.spec.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.spec.ts
@@ -195,6 +195,7 @@ describe('Link Set Utils', () => {
             ],
             method: 'POST',
             public: true,
+            rel: ['edit', 'latest-version'],
           },
         ],
       };
@@ -212,6 +213,7 @@ describe('Link Set Utils', () => {
       ]);
       expect(linkTargets[0].method).toBe('POST');
       expect(linkTargets[0].public).toBe(true);
+      expect(linkTargets[0].rel).toEqual(['edit', 'latest-version']);
     });
 
     it.each([true, false])(
@@ -287,6 +289,64 @@ describe('Link Set Utils', () => {
       expect(linkTargets[0]).not.toHaveProperty('accessRole');
       expect(linkTargets[0]).not.toHaveProperty('method');
       expect(linkTargets[0]).not.toHaveProperty('public');
+      expect(linkTargets[0]).not.toHaveProperty('rel');
+    });
+
+    it('should keep publisher-set rel separate from server-derived predecessor-version', () => {
+      const uri: LinkSetInput = {
+        namespace: 'idr',
+        identificationKeyType: 'test',
+        identificationKey: '12345',
+        description: 'example',
+        qualifierPath: '/',
+        active: true,
+        responses: [
+          {
+            linkId: 'link1',
+            linkType: 'gs1:certificationInfo',
+            targetUrl: 'https://example.com/cert',
+            title: 'Certification',
+            mimeType: 'application/json',
+            ianaLanguage: 'en',
+            context: 'us',
+            active: true,
+            fwqs: false,
+            defaultLinkType: true,
+            defaultIanaLanguage: true,
+            defaultContext: true,
+            defaultMimeType: true,
+            rel: ['edit'],
+          },
+        ],
+      };
+
+      const versionHistory: VersionHistoryEntry[] = [
+        {
+          version: 2,
+          updatedAt: '2024-06-01T00:00:00.000Z',
+          changes: [
+            {
+              linkId: 'link1',
+              action: 'updated' as const,
+              previousTargetUrl: 'https://example.com/old-cert',
+            },
+          ],
+        },
+      ];
+
+      const result = constructLinkSetJson(uri, '01', attrs, versionHistory);
+      const linkTypeEntries =
+        result['https://linktypevoc.example.com/voc/certificationInfo'];
+
+      const current = linkTypeEntries.find(
+        (e: any) => e.href === 'https://example.com/cert',
+      );
+      const predecessor = linkTypeEntries.find(
+        (e: any) => e.href === 'https://example.com/old-cert',
+      );
+
+      expect(current.rel).toEqual(['edit']);
+      expect(predecessor.rel).toEqual(['predecessor-version']);
     });
 
     it('should include predecessor-version entries from version history', () => {

--- a/app/src/modules/link-registration/utils/link-set.utils.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.ts
@@ -130,6 +130,9 @@ const constructLinkTargetObjects = (
           if (firstGroupedResponse.public !== undefined) {
             linkTarget.public = firstGroupedResponse.public;
           }
+          if (firstGroupedResponse.rel?.length > 0) {
+            linkTarget.rel = firstGroupedResponse.rel;
+          }
 
           acc[key].push(linkTarget);
         },

--- a/app/src/modules/link-resolution/interfaces/uri.interface.ts
+++ b/app/src/modules/link-resolution/interfaces/uri.interface.ts
@@ -22,6 +22,7 @@ export interface LinkResponse {
   method?: string;
   /** @see {@link LinkTargetObject.public} from `../../link-registration/interfaces/link-set.interface` */
   public?: boolean;
+  rel?: string[];
 }
 
 export interface LinkChange {


### PR DESCRIPTION
This PR adds the optional `rel: string[]` field to link target variants
on the `Response` DTO (POST `/resolver`) and `UpdateLinkDto`
(PUT `/resolver/links/:linkId`), with persistence and linkset emission
wired end-to-end. The field carries additional link relation types per
RFC 8288 that qualify a link beyond its primary linkType (e.g. `edit`,
`latest-version`).

DTO decoration is centralised in a `@RelProperty()` composite decorator
that bundles the OpenAPI metadata, the array-of-strings validator, and
a `class-transformer @Transform` that silently strips
`predecessor-version` from publisher input. That value is reserved by
the server for version-history entries; the strip prevents collision
without forcing clients to know the reservation. The server-derived
`predecessor-version` emission on predecessor entries is unchanged.

The POST `/resolver` pipe now sets `transform: true` so the strip runs
at the handler boundary, matching the sister PUT controller's
convention.

Closes #99

## Test plan
- [x] Publisher's `rel: ['edit']` round-trips through Response/UpdateLinkDto persistence and the linkset emission
- [x] `predecessor-version` is silently stripped from publisher input on both DTOs
- [x] Publisher's `rel` and server-derived `rel: ['predecessor-version']` coexist as separate entries in the same linkset (predecessor entries keep their server-set rel; current entries keep the publisher's)
- [x] `updateLink({ rel: [] })` clears (replace semantics on PATCH)
- [x] `updateLink({ rel: null })` is accepted (treated as absent at the linkset boundary)
- [x] `rel`-only updates record `action: 'updated'` with no `previousX` fields (not part of the composite key)
- [x] Non-array `rel` is rejected
- [x] Full unit suite passes (46 suites, 447 tests)