### PR TITLE
docs(adr): accept ADR 001 link variant capability model

### DIFF
--- a/docs/adr/001-link-variant-capability-model.md
+++ b/docs/adr/001-link-variant-capability-model.md
@@ -1,0 +1,72 @@
+# ADR 001: Link target variants as capability advertisement
+
+## Status
+
+accepted
+
+## Context
+
+The Pyx Identity Resolver (IDR) models registered link variants for an identifier. Each variant points at a target URL with metadata describing what the target serves. Two questions sit at the centre of the variant model:
+
+1. What does a variant entry represent? A single concrete (URL, language, format) tuple, or a single URL endpoint with a capability profile?
+2. Where does per-request content negotiation happen? In the resolver (which switches between variant rows based on the client's preferences), or in the target service (which inspects the request and responds appropriately)?
+
+Two adjacent constraints frame the answer.
+
+The UNTP Identity Resolver v0.7 specification (LinksetSchema) defines `hreflang` on each link target as an array of BCP 47 language tags, with no separate single-value language field or default-language flag. The spec embeds a particular model for how variants represent language coverage.
+
+The current IDR (v3.x) models language as a single-value `ianaLanguage` field per variant plus a `defaultIanaLanguage` boolean, with `ianaLanguage` participating in the variant composite key. Under this model, registering a service that serves three languages requires three variant entries that differ only by `ianaLanguage`, and the composite key forces the resolver to treat each language as a distinct addressable variant.
+
+Conforming to UNTP IDR v0.7 is the immediate driver; the v0.7 milestone (#104) tracks the full conformance push and this is one of several structural changes within it. Other v0.7 changes (`rel`, `public`, permissive `mimeType`, OpenAPI hygiene) shipped in #99, #100, #101, and #103 without raising the same architectural question because they were additive metadata. The hreflang change is different: it forces a choice between two coherent models of what a variant is for, and the choice ripples through the composite key, the resolver, and the linkset emission.
+
+## Decision
+
+A link target variant in the IDR represents a single URL endpoint that advertises the set of language representations it serves. The IDR does not split a service into per-language variant entries. When a client requests a specific language, the IDR selects between services whose advertised `hreflang[]` contains the requested tag and redirects to the chosen URL; the target service performs per-request content negotiation (RFC 9110 §12 server-driven negotiation, typically via `Accept-Language` per §12.5.4) to return the appropriate representation.
+
+Concretely:
+
+- `hreflang: string[]` on each variant, optional, with BCP 47 validation per item per the LinksetSchema regex.
+- `ianaLanguage` and `defaultIanaLanguage` removed.
+- Variant composite key is `(targetUrl, linkType, mimeType, context)`; language is not part of variant identity.
+- The resolver's role for language is to route (which service serves this language), not to negotiate format (which language representation to return).
+
+## Consequences
+
+**Easier:**
+
+- A single registered URL accurately describes a multi-lingual service. Publishers stop maintaining N redundant rows that differ only by language tag.
+- The variant key is simpler. Conflict detection and update tracking shrink by one field.
+- The model aligns with the UNTP IDR v0.7 LinksetSchema and with how RFC 9110 expects HTTP services to behave. Future consumers reading the linkset can rely on standard HTTP semantics for the final hop.
+- The resolver does less. It does not own the question "which language representation does this client want?" beyond capability-level routing.
+
+**Harder:**
+
+- Target services must do their own content negotiation. The IDR no longer hides services that don't honour `Accept-Language` — a non-negotiating service registered with multiple `hreflang` values may return the wrong language. This is the publisher's responsibility, not the IDR's.
+- Existing stored variant data uses the old model and must be migrated to the 4-tuple key with merged hreflang arrays (#109).
+- This is a breaking change to the public API contract. Publishers integrating with the IDR must update their registration payloads. Released as a major version bump.
+
+## Open question: mimeType asymmetry
+
+The capability-advertisement model implies that `mimeType` (the linkset's `type` field) should also be an array, since the same content-negotiation argument applies to format: a service that serves both `application/vc+ld+json` and `application/vc+jwt` from the same URL should be expressible as one variant with both formats. The UNTP IDR v0.7 LinksetSchema keeps `type` as a single string, so the IDR follows the spec exactly. The asymmetry is tracked at #118, which proposes raising an upstream question with the UNTP maintainers. If the spec is updated, this ADR will be revisited.
+
+## Alternatives Considered
+
+**Per-language variant entries (status quo v3.x model).** Rejected. The model treats language as part of variant identity, which forces publishers to register one URL per language even when the underlying service handles content negotiation. It also diverges from the UNTP IDR v0.7 LinksetSchema, which would block downstream consumers that expect the v0.7 shape.
+
+**hreflang as an array but keep `ianaLanguage` as a "default" or "primary" single-value field.** Rejected. The two representations would carry overlapping information with no normative rule for which wins on conflict. The UNTP spec does not include any per-variant "primary language" concept, so the extra field would have no upstream meaning. It would also leave the composite key at 5 fields, defeating the simplification.
+
+**Soft-deprecation of `ianaLanguage` as an alias.** Accept old-shape payloads and internally map `ianaLanguage: 'en'` to `hreflang: ['en']`, similar to the `itemDescription` to `description` deprecation that shipped in #96. Rejected. The migration carries data-shape implications beyond the input layer (composite key, version-history tracking, linkset emission), and the alias would persist long after the cut-over because consumers would have no forcing function to update. A clean break aligned with a major version bump confines the cost to one release window.
+
+**Resolver-side content negotiation (keep per-language variants and have the resolver match `Accept-Language` directly to one of them).** Rejected. Builds resolver-internal logic that duplicates work HTTP servers already do, and entrenches the per-language variant model the spec moved away from. It also pushes the resolver into a representation-switching role that conflates routing with content negotiation; future format dimensions (encodings, scripts) would each need parallel handling.
+
+## References
+
+- #106 — Publishers can register and retrieve a link variant with hreflang
+- #104 — Epic: UNTP IDR v0.7 conformance
+- #109 — Migrate existing stored link variants to the new 4-tuple key model
+- #116 — Follow-up: Resolver honours `Accept-Language` header
+- #117 — Follow-up: Resolver applies BCP 47 fallback when matching hreflang
+- #118 — Follow-up: Raise upstream question about `type` singular vs `hreflang` array
+- UNTP IDR LinksetSchema — `hreflang` definition
+- RFC 9110 §12 — Content Negotiation
+- RFC 9264 — Linkset format

--- a/docs/adr/001-link-variant-capability-model.md
+++ b/docs/adr/001-link-variant-capability-model.md
@@ -1,8 +1,7 @@
 # ADR 001: Link target variants as capability advertisement
 
-## Status
-
-accepted
+- **Date:** 2026-05-21
+- **Status:** accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,62 @@
+# Architectural Decision Records (ADRs)
+
+## What are ADRs?
+
+Architectural Decision Records capture significant structural and architectural decisions made during the development of this project. Each ADR describes a decision, its context, the alternatives considered, and the consequences of the choice made.
+
+This project uses ADRs to maintain a transparent, searchable history of *why* the codebase is shaped the way it is — not just *what* was built.
+
+## Where they live
+
+All ADRs are stored in `docs/adr/` at the repository root.
+
+## Naming convention
+
+ADR files follow this pattern:
+
+```
+NNN-short-slug.md
+```
+
+Where `NNN` is a zero-padded sequence number assigned at creation time (next free number; do not reuse retired numbers). For example: `001-link-variant-capability-model.md`.
+
+Use lowercase, hyphen-separated slugs. Keep them short but descriptive.
+
+## Status lifecycle
+
+Every ADR has a status field that follows this lifecycle:
+
+```
+proposed → accepted → superseded / deprecated
+```
+
+| Status | Meaning |
+|---|---|
+| **proposed** | Under discussion; not yet agreed upon |
+| **accepted** | Agreed and in effect |
+| **superseded** | Replaced by a newer ADR (link to the replacement) |
+| **deprecated** | No longer relevant; withdrawn without a replacement |
+
+## When to create an ADR
+
+Create an ADR for **structural and architectural decisions only**:
+
+- New patterns or conventions that affect the codebase structure
+- Technology choices (frameworks, libraries, infrastructure)
+- Service boundaries and integration approaches
+- Data model design decisions
+- Deployment topology changes
+- Authentication/authorisation strategy changes
+
+**Do not** create an ADR for:
+
+- Bug fixes
+- Minor code style or formatting choices
+- Routine dependency updates
+- Individual feature implementations (unless they introduce a new pattern)
+
+## How to create one
+
+**Preferred:** Use the `creating-adrs` skill, which guides you through the process.
+
+**Manual:** Copy `TEMPLATE.md` from this directory, rename it following the naming convention above, and fill in each section.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,25 @@
+# ADR: [Title]
+
+- **Date:** YYYY-MM-DD
+- **Status:** proposed | accepted | superseded | deprecated
+- **Superseded by:** [ADR link, if applicable]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+## Alternatives Considered
+
+What other approaches were evaluated? Why were they rejected?
+
+## References
+
+Links to specs, PRs, issues, external resources, or related ADRs.


### PR DESCRIPTION
This PR records the first architecture decision in the repository, ADR 001 "Link target variants as capability advertisement", introducing the `docs/adr/` directory in the process. The decision establishes that a link target variant represents a single URL endpoint that advertises the set of language representations it serves, with per-request content negotiation delegated to the target service per RFC 9110 §12. The IDR does not split a service into per-language variant entries.

The decision is the structural foundation for the hreflang work tracked at #106 and the rest of the UNTP IDR v0.7 conformance epic at #104. The variant composite key shrinks from a 5-tuple to a 4-tuple as a direct consequence, since language is no longer part of variant identity.

Three follow-up issues are referenced from the ADR and tracked against the epic: #116 (Accept-Language header support), #117 (BCP 47 fallback matching), and #118 (raise upstream question about the `type` vs `hreflang` asymmetry in the UNTP LinksetSchema).

The ADR is filed as `accepted` because the decision was made and aligned on before the PR was raised; this matches the v3.x to v4 break that the hreflang implementation work depends on.

Related to #104, #106