### PR TITLE
feat(link-registration): emit per-variant hreflang on linkset targets

### DIFF
--- a/app/src/modules/link-registration/utils/link-set.utils.spec.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.spec.ts
@@ -94,11 +94,13 @@ describe('Link Set Utils', () => {
             href: 'https://example2.com',
             title: 'example2',
             type: 'application/json',
+            hreflang: ['en'],
           },
           {
             href: 'https://example.com',
             title: 'example',
             type: 'application/json',
+            hreflang: ['en'],
           },
         ],
         'https://linktypevoc.example.com/voc/exampleLinkType2': [
@@ -106,11 +108,13 @@ describe('Link Set Utils', () => {
             href: 'https://example4.com',
             title: 'example4',
             type: '',
+            hreflang: [],
           },
           {
             href: 'https://example3.com',
             title: 'example3',
             type: 'application/json',
+            hreflang: ['en'],
           },
         ],
       };
@@ -197,6 +201,7 @@ describe('Link Set Utils', () => {
       expect(linkTargets[0].method).toBe('POST');
       expect(linkTargets[0].public).toBe(true);
       expect(linkTargets[0].rel).toEqual(['edit', 'latest-version']);
+      expect(linkTargets[0].hreflang).toEqual(['en']);
     });
 
     it.each([true, false])(
@@ -249,7 +254,6 @@ describe('Link Set Utils', () => {
             targetUrl: 'https://example.com/cert',
             title: 'Certification',
             mimeType: 'application/json',
-            hreflang: ['en'],
             context: 'us',
             active: true,
             fwqs: false,
@@ -271,6 +275,39 @@ describe('Link Set Utils', () => {
       expect(linkTargets[0]).not.toHaveProperty('method');
       expect(linkTargets[0]).not.toHaveProperty('public');
       expect(linkTargets[0]).not.toHaveProperty('rel');
+      expect(linkTargets[0].hreflang).toEqual([]);
+    });
+
+    it('should emit an empty `hreflang` array when explicitly set on the variant', () => {
+      const uri: LinkSetInput = {
+        namespace: 'idr',
+        identificationKeyType: 'test',
+        identificationKey: '12345',
+        description: 'example',
+        qualifierPath: '/',
+        active: true,
+        responses: [
+          {
+            linkType: 'gs1:certificationInfo',
+            targetUrl: 'https://example.com/cert',
+            title: 'Certification',
+            mimeType: 'application/json',
+            hreflang: [],
+            context: 'us',
+            active: true,
+            fwqs: false,
+            defaultLinkType: true,
+            defaultContext: true,
+            defaultMimeType: true,
+          },
+        ],
+      };
+
+      const result = constructLinkSetJson(uri, '01', attrs);
+      const linkTargets =
+        result['https://linktypevoc.example.com/voc/certificationInfo'];
+
+      expect(linkTargets[0].hreflang).toEqual([]);
     });
 
     it('should keep publisher-set rel separate from server-derived predecessor-version', () => {

--- a/app/src/modules/link-registration/utils/link-set.utils.ts
+++ b/app/src/modules/link-registration/utils/link-set.utils.ts
@@ -89,10 +89,6 @@ const constructLinkTargetObjects = (
 
       acc[key] = [];
 
-      // Construct the link target objects.
-      // hreflang emission is intentionally absent here; per-variant
-      // hreflang reading is reintroduced when the linkset emission lands
-      // (#107). See `docs/adr/001-link-variant-capability-model.md`.
       Object.values(groupResponsesByMimeTypeTargetUrlAndContext).map(
         (groupedResponses: any) => {
           const firstGroupedResponse = groupedResponses[0];
@@ -124,6 +120,7 @@ const constructLinkTargetObjects = (
           if (firstGroupedResponse.rel?.length > 0) {
             linkTarget.rel = firstGroupedResponse.rel;
           }
+          linkTarget.hreflang = firstGroupedResponse.hreflang ?? [];
 
           acc[key].push(linkTarget);
         },

--- a/app/test/link-registration/hreflang-linkset-emission.e2e-spec.ts
+++ b/app/test/link-registration/hreflang-linkset-emission.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { HttpStatus } from '@nestjs/common';
+import request from 'supertest';
+import { APP_ROUTE_PREFIX } from '../../src/common/utils/config.utils';
+import { IdentifierDto } from 'src/modules/identifier-management/dto/identifier.dto';
+
+const baseUrl = process.env.API_BASE_URL + APP_ROUTE_PREFIX;
+const environment = process.env.NODE_ENV;
+const apiKey = process.env.API_KEY;
+
+const namespace = `e2e-${environment}-mock-hreflang-emission`;
+const identificationKeyType = 'gtin';
+const qualifierPath = '/';
+
+const identifierDto = (): IdentifierDto => ({
+  namespace,
+  namespaceProfile: '',
+  namespaceURI: '',
+  applicationIdentifiers: [
+    {
+      ai: '01',
+      shortcode: 'gtin',
+      type: 'I',
+      title: 'Global Trade Item Number (GTIN)',
+      label: 'GTIN',
+      regex: '(\\d{12,14}|\\d{8})',
+      qualifiers: [],
+    },
+  ],
+});
+
+const headers = {
+  Accept: 'application/json',
+  Authorization: `Bearer ${apiKey}`,
+};
+
+const buildPayload = (identificationKey: string, hreflang: string[]) => ({
+  namespace,
+  identificationKeyType,
+  identificationKey,
+  description: 'Hreflang linkset emission test',
+  qualifierPath,
+  active: true,
+  responses: [
+    {
+      defaultLinkType: true,
+      defaultMimeType: true,
+      defaultContext: true,
+      fwqs: false,
+      active: true,
+      linkType: 'gs1:certificationInfo',
+      context: 'au',
+      title: 'Certification Information',
+      targetUrl: 'https://example.com/cert',
+      mimeType: 'application/json',
+      hreflang,
+    },
+  ],
+});
+
+const fetchLinkset = async (identificationKey: string) => {
+  const res = await request(baseUrl)
+    .get(`/${namespace}/01/${identificationKey}?linkType=all`)
+    .set('Accept', 'application/json')
+    .expect(HttpStatus.OK);
+  return res.body.linkset[0];
+};
+
+const certInfoTargets = (linkset: any) => {
+  const key = Object.keys(linkset).find((k) =>
+    k.endsWith('/certificationInfo'),
+  );
+  return key ? linkset[key] : undefined;
+};
+
+describe('LinkRegistration — hreflang linkset emission (e2e)', () => {
+  beforeAll(async () => {
+    await request(baseUrl)
+      .post('/identifiers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .send(identifierDto())
+      .expect(HttpStatus.OK);
+  });
+
+  afterAll(async () => {
+    await request(baseUrl)
+      .delete('/identifiers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .query({ namespace })
+      .expect(HttpStatus.OK);
+  });
+
+  it('emits per-variant hreflang on the published linkset target', async () => {
+    const identificationKey = '22345678901234';
+    await request(baseUrl)
+      .post('/resolver')
+      .set(headers)
+      .send(buildPayload(identificationKey, ['en', 'fr', 'de']))
+      .expect(HttpStatus.CREATED);
+
+    const linkset = await fetchLinkset(identificationKey);
+    const targets = certInfoTargets(linkset);
+
+    expect(targets).toBeDefined();
+    expect(targets).toHaveLength(1);
+    expect(targets[0].hreflang).toEqual(['en', 'fr', 'de']);
+  });
+
+  it('emits an empty hreflang array on the linkset target when explicitly set', async () => {
+    const identificationKey = '22345678901235';
+    await request(baseUrl)
+      .post('/resolver')
+      .set(headers)
+      .send(buildPayload(identificationKey, []))
+      .expect(HttpStatus.CREATED);
+
+    const linkset = await fetchLinkset(identificationKey);
+    const targets = certInfoTargets(linkset);
+
+    expect(targets).toBeDefined();
+    expect(targets).toHaveLength(1);
+    expect(targets[0].hreflang).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR restores the per-variant `hreflang` field on each link target of the published linkset, matching the UNTP IDR v0.7 LinksetSchema target shape. #106 retired the legacy language fan-in (where multiple variants sharing a `targetUrl` were merged into a single `hreflang` array); #107 replaces that with per-variant emission reading from the source response's `hreflang` as stored.

`hreflang` is always emitted on current link target entries. When the source variant has no declared value the array is synthesised as `[]` so consumers never need to handle the missing case. Predecessor-version entries do not carry `hreflang` since they exist solely to identify historical URLs and language coverage adds no useful traceability.

Closes #107

## Test plan
- [x] Linkset construction emits the variant's `hreflang` array verbatim when declared (snapshot test in `link-set.utils.spec.ts`)
- [x] Linkset construction emits `hreflang: []` when the variant has no declared value
- [x] Predecessor-version entries do not carry `hreflang`
- [x] New e2e covering POST then fetch `?linkType=all` then assert `hreflang` round-trips through the published linkset (populated and empty-array cases)
- [x] Full unit suite passes (47 suites, 494 tests)