### PR TITLE
feat(migration): v4 data migration for the 4-tuple key model

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -110,8 +110,7 @@ cp .env.development.local.example .env.development.local
 - `OBJECT_STORAGE_BUCKET_NAME`: The MinIO bucket name for storing data.
 - `OBJECT_STORAGE_PATH_STYLE`: Enable or disable path-style requests for MinIO. Set to `false` for cloud providers. Set to `true` if you are using MinIO Gateway. By default, it is set to `true`.
 - `IDENTIFIER_PATH`: The path to the identifier data file.
-- `RESOLVER_DOMAIN`: The domain name for this resolver service.
-- `LINK_TYPE_VOC_DOMAIN`: The domain name for the link type vocabulary.
+- `RESOLVER_DOMAIN`: Externally-reachable base URL for this resolver service (scheme + host, no path, no trailing slash). The service appends the API path prefix (`/api/v4`) internally based on `apiVersion` in `version.json`. The link-type vocabulary URL is derived from `RESOLVER_DOMAIN` + the API path prefix + `/voc`, and can be overridden per identifier by setting `namespaceURI` on the identifier record.
 - `API_KEY`: The API key for accessing any protected endpoints in this service.
 - `APP_NAME`: The name of this application.
 

--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json --detectOpenHandles"
+    "test:e2e": "jest --config ./test/jest-e2e.json --detectOpenHandles",
+    "migrate:v4": "ts-node -r tsconfig-paths/register ./src/migration/v4-cli.ts"
   },
   "dependencies": {
     "@codegenie/serverless-express": "^4.15.0",

--- a/app/src/migration/v4-cli.ts
+++ b/app/src/migration/v4-cli.ts
@@ -1,0 +1,241 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { IRepositoryProvider } from '../repository/providers/provider.repository.interface';
+import { buildApiBaseUrl } from '../common/utils/config.utils';
+import { migrateUriDocument } from './v4-transform';
+import {
+  parseArgs,
+  describeOutcome,
+  HELP_TEXT,
+  Options,
+  ParseResult,
+  Summary,
+} from './v4-cli.utils';
+
+const LINK_INDEX_PREFIX = '_index/links/';
+
+interface IdentifierRecord {
+  namespace: string;
+  namespaceURI?: string;
+}
+
+async function main() {
+  let parsed: ParseResult;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(2);
+  }
+  if (parsed.helpRequested) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+  const opts = parsed.options;
+  const logger = new Logger('migrate:v4');
+
+  if (opts.dryRun) {
+    logger.log('Dry-run mode: no objects will be written.');
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+
+  const repo = app.get<IRepositoryProvider>('RepositoryProvider');
+  const config = app.get(ConfigService);
+
+  const identifierPath = config.get<string>('IDENTIFIER_PATH') ?? 'identifiers';
+
+  let apiBaseUrl: string;
+  try {
+    apiBaseUrl = buildApiBaseUrl(config);
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    await app.close();
+    process.exit(2);
+  }
+
+  const summary: Summary = {
+    scanned: 0,
+    migrated: 0,
+    noop: 0,
+    failed: [],
+  };
+
+  try {
+    if (opts.only) {
+      await processOne(
+        opts.only,
+        repo,
+        identifierPath,
+        apiBaseUrl,
+        opts,
+        summary,
+        logger,
+      );
+    } else {
+      await processAll(repo, identifierPath, apiBaseUrl, opts, summary, logger);
+    }
+  } finally {
+    await app.close();
+  }
+
+  logger.log('---');
+  logger.log(`Scanned:  ${summary.scanned}`);
+  logger.log(`Migrated: ${summary.migrated}${opts.dryRun ? ' (dry-run)' : ''}`);
+  logger.log(`No-ops:   ${summary.noop}`);
+  logger.log(`Failed:   ${summary.failed.length}`);
+  if (summary.failed.length) {
+    for (const failure of summary.failed) {
+      logger.error(`  ${failure.id}: ${failure.error}`);
+    }
+    process.exit(1);
+  }
+}
+
+function resolveLinkTypeVocDomain(
+  identifier: IdentifierRecord | undefined,
+  apiBaseUrl: string,
+): string {
+  return identifier?.namespaceURI && identifier.namespaceURI !== ''
+    ? identifier.namespaceURI
+    : `${apiBaseUrl}/voc`;
+}
+
+async function processAll(
+  repo: IRepositoryProvider,
+  identifierPath: string,
+  apiBaseUrl: string,
+  opts: Options,
+  summary: Summary,
+  logger: Logger,
+): Promise<void> {
+  const identifiers = await repo.all<IdentifierRecord>(identifierPath);
+  for (const identifier of identifiers) {
+    if (!identifier?.namespace) continue;
+    const linkTypeVocDomain = resolveLinkTypeVocDomain(identifier, apiBaseUrl);
+    const docs = await repo.all<any>(`${identifier.namespace}/`);
+    for (const doc of docs) {
+      if (!isUriDocument(doc)) continue;
+      await processDoc(doc, repo, opts, summary, logger, {
+        resolverDomain: apiBaseUrl,
+        linkTypeVocDomain,
+      });
+    }
+  }
+}
+
+async function processOne(
+  id: string,
+  repo: IRepositoryProvider,
+  identifierPath: string,
+  apiBaseUrl: string,
+  opts: Options,
+  summary: Summary,
+  logger: Logger,
+): Promise<void> {
+  const doc = await repo.one<any>(id);
+  if (!doc) {
+    summary.failed.push({ id, error: 'document not found' });
+    return;
+  }
+  if (!isUriDocument(doc)) {
+    summary.failed.push({
+      id,
+      error: 'not a URI document (no `responses` array)',
+    });
+    return;
+  }
+  const identifier = await repo.one<IdentifierRecord>(
+    `${identifierPath}/${doc.namespace}`,
+  );
+  const linkTypeVocDomain = resolveLinkTypeVocDomain(
+    identifier ?? undefined,
+    apiBaseUrl,
+  );
+  await processDoc(doc, repo, opts, summary, logger, {
+    resolverDomain: apiBaseUrl,
+    linkTypeVocDomain,
+  });
+}
+
+async function processDoc(
+  doc: any,
+  repo: IRepositoryProvider,
+  opts: Options,
+  summary: Summary,
+  logger: Logger,
+  attrs: { resolverDomain: string; linkTypeVocDomain: string },
+): Promise<void> {
+  summary.scanned += 1;
+  const id = doc.id ?? '(unknown id)';
+  try {
+    const { document, outcome } = migrateUriDocument(doc, attrs);
+    if (!outcome.mutated) {
+      summary.noop += 1;
+      if (opts.verbose) {
+        logger.log(`[noop] ${id}: already in v4 shape`);
+      }
+      return;
+    }
+    summary.migrated += 1;
+    const description = describeOutcome(outcome);
+    if (opts.dryRun) {
+      logger.log(`[would-migrate] ${id}: ${description}`);
+      return;
+    }
+    await repo.save(document);
+    await deleteOrphanLinkIndexes(repo, outcome.discardedLinkIds, logger, id);
+    logger.log(`[migrated] ${id}: ${description}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    summary.failed.push({ id, error: message });
+    logger.error(`[failed] ${id}: ${message}`);
+    if (!opts.continueOnError) {
+      throw new Error(
+        `Aborting on first failure (re-run with --continue-on-error to skip).`,
+      );
+    }
+  }
+}
+
+async function deleteOrphanLinkIndexes(
+  repo: IRepositoryProvider,
+  discardedLinkIds: string[],
+  logger: Logger,
+  docId: string,
+): Promise<void> {
+  for (const linkId of discardedLinkIds) {
+    const objectName = `${LINK_INDEX_PREFIX}${linkId}.json`;
+    try {
+      await repo.delete(objectName);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(
+        `[orphan-index] ${docId}: could not delete ${objectName}: ${message}`,
+      );
+    }
+  }
+}
+
+function isUriDocument(doc: any): boolean {
+  return (
+    !!doc &&
+    typeof doc === 'object' &&
+    Array.isArray(doc.responses) &&
+    typeof doc.namespace === 'string' &&
+    typeof doc.identificationKey === 'string'
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/app/src/migration/v4-cli.utils.spec.ts
+++ b/app/src/migration/v4-cli.utils.spec.ts
@@ -1,0 +1,96 @@
+import { parseArgs, describeOutcome, HELP_TEXT } from './v4-cli.utils';
+import { MigrationOutcome } from './v4-transform';
+
+const outcome = (over: Partial<MigrationOutcome> = {}): MigrationOutcome => ({
+  mutated: true,
+  inputResponseCount: 1,
+  outputResponseCount: 1,
+  rewrittenVersionEntries: 0,
+  discardedLinkIds: [],
+  ...over,
+});
+
+describe('parseArgs', () => {
+  it('returns default options for an empty argv', () => {
+    expect(parseArgs([])).toEqual({
+      options: {
+        dryRun: false,
+        continueOnError: false,
+        verbose: false,
+      },
+      helpRequested: false,
+      helpText: HELP_TEXT,
+    });
+  });
+
+  it('parses --dry-run, --continue-on-error and --verbose flags', () => {
+    const { options } = parseArgs([
+      '--dry-run',
+      '--continue-on-error',
+      '--verbose',
+    ]);
+    expect(options.dryRun).toBe(true);
+    expect(options.continueOnError).toBe(true);
+    expect(options.verbose).toBe(true);
+  });
+
+  it('parses --only with a value', () => {
+    const { options } = parseArgs(['--only', 'gs1/01/09359502000041']);
+    expect(options.only).toBe('gs1/01/09359502000041');
+  });
+
+  it('throws when --only is missing its value', () => {
+    expect(() => parseArgs(['--only'])).toThrow(
+      '--only requires a document id argument',
+    );
+  });
+
+  it('sets helpRequested for -h and --help instead of exiting', () => {
+    expect(parseArgs(['-h']).helpRequested).toBe(true);
+    expect(parseArgs(['--help']).helpRequested).toBe(true);
+  });
+
+  it('throws on an unrecognised argument', () => {
+    expect(() => parseArgs(['--bogus'])).toThrow(
+      'Unrecognised argument: --bogus',
+    );
+  });
+});
+
+describe('describeOutcome', () => {
+  it('shows the variant count when no merge occurred', () => {
+    expect(
+      describeOutcome(
+        outcome({ inputResponseCount: 2, outputResponseCount: 2 }),
+      ),
+    ).toBe('2 variants');
+  });
+
+  it('shows the input -> output collapse when variants were merged', () => {
+    expect(
+      describeOutcome(
+        outcome({ inputResponseCount: 3, outputResponseCount: 1 }),
+      ),
+    ).toContain('3 variants');
+    expect(
+      describeOutcome(
+        outcome({ inputResponseCount: 3, outputResponseCount: 1 }),
+      ),
+    ).toContain('merged 2');
+  });
+
+  it('appends the rewritten-history count when nonzero', () => {
+    expect(describeOutcome(outcome({ rewrittenVersionEntries: 4 }))).toContain(
+      '4 version entries rewritten',
+    );
+  });
+
+  it('appends the discarded link-id count (singular and plural)', () => {
+    expect(describeOutcome(outcome({ discardedLinkIds: ['lnk-1'] }))).toContain(
+      '1 discarded variant link-id',
+    );
+    expect(
+      describeOutcome(outcome({ discardedLinkIds: ['lnk-1', 'lnk-2'] })),
+    ).toContain('2 discarded variant link-ids');
+  });
+});

--- a/app/src/migration/v4-cli.utils.ts
+++ b/app/src/migration/v4-cli.utils.ts
@@ -1,0 +1,111 @@
+import { MigrationOutcome } from './v4-transform';
+
+export interface Options {
+  dryRun: boolean;
+  continueOnError: boolean;
+  only?: string;
+  verbose: boolean;
+}
+
+export interface Summary {
+  scanned: number;
+  migrated: number;
+  noop: number;
+  failed: { id: string; error: string }[];
+}
+
+export interface ParseResult {
+  options: Options;
+  helpRequested: boolean;
+  helpText: string;
+}
+
+export const HELP_TEXT = `
+Usage: yarn migrate:v4 [options]
+
+Migrates stored URI documents from the legacy 5-tuple key model
+(targetUrl, linkType, mimeType, ianaLanguage, context) to the v4 4-tuple
+model (targetUrl, linkType, mimeType, context). See
+documentation/docs/migration-guides/v4.md before running.
+
+Options:
+  --dry-run               List what would change without writing anything.
+  --continue-on-error     Keep migrating other documents if one fails.
+                          Default is to abort on the first failure.
+  --only <id>             Migrate a single document by storage id, e.g.
+                          --only gs1/01/09359502000041
+  --verbose               Log each scanned document (default: skipped no-ops
+                          are silent).
+  -h, --help              Print this help and exit.
+`;
+
+/**
+ * Parses the CLI argv slice for `yarn migrate:v4`. Returns the parsed
+ * options and a `helpRequested` flag so the caller can decide whether
+ * to print help and exit, rather than `process.exit`-ing from inside
+ * the parser (which would make the parser untestable).
+ *
+ * @throws if `--only` is missing its value or an unknown argument is
+ *   passed.
+ */
+export function parseArgs(argv: string[]): ParseResult {
+  const options: Options = {
+    dryRun: false,
+    continueOnError: false,
+    verbose: false,
+  };
+  let helpRequested = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--continue-on-error':
+        options.continueOnError = true;
+        break;
+      case '--only':
+        options.only = argv[++i];
+        if (!options.only) {
+          throw new Error('--only requires a document id argument');
+        }
+        break;
+      case '--verbose':
+        options.verbose = true;
+        break;
+      case '-h':
+      case '--help':
+        helpRequested = true;
+        break;
+      default:
+        throw new Error(`Unrecognised argument: ${arg}`);
+    }
+  }
+  return { options, helpRequested, helpText: HELP_TEXT };
+}
+
+/**
+ * Renders a single-line human-readable summary of one document's
+ * migration outcome for the CLI logger. Empty when no observable
+ * changes were applied.
+ */
+export function describeOutcome(outcome: MigrationOutcome): string {
+  const parts: string[] = [];
+  if (outcome.inputResponseCount !== outcome.outputResponseCount) {
+    const collapsed = outcome.inputResponseCount - outcome.outputResponseCount;
+    parts.push(
+      `${outcome.inputResponseCount} variants -> ${outcome.outputResponseCount} (merged ${collapsed})`,
+    );
+  } else {
+    parts.push(`${outcome.outputResponseCount} variants`);
+  }
+  if (outcome.rewrittenVersionEntries > 0) {
+    parts.push(`${outcome.rewrittenVersionEntries} version entries rewritten`);
+  }
+  if (outcome.discardedLinkIds.length > 0) {
+    parts.push(
+      `${outcome.discardedLinkIds.length} discarded variant ${outcome.discardedLinkIds.length === 1 ? 'link-id' : 'link-ids'}`,
+    );
+  }
+  return parts.join('; ');
+}

--- a/app/src/migration/v4-transform.spec.ts
+++ b/app/src/migration/v4-transform.spec.ts
@@ -1,0 +1,581 @@
+import { migrateUriDocument } from './v4-transform';
+
+const attrs = {
+  resolverDomain: 'http://localhost:3000/api/4.0.0',
+  linkTypeVocDomain: 'http://localhost:3000/api/4.0.0/voc',
+};
+
+const baseLegacyDoc = () => ({
+  id: 'gs1/01/09359502000041',
+  namespace: 'gs1',
+  identificationKeyType: 'gtin',
+  identificationKey: '09359502000041',
+  description: 'DPP',
+  qualifierPath: '/',
+  active: true,
+});
+
+const baseLegacyResponse = (over: Record<string, unknown> = {}): any => ({
+  targetUrl: 'https://example.com/cert',
+  title: 'Certification Information',
+  linkType: 'gs1:certificationInfo',
+  context: 'us',
+  mimeType: 'application/json',
+  active: true,
+  fwqs: false,
+  defaultLinkType: true,
+  defaultContext: true,
+  defaultMimeType: true,
+  linkId: 'lnk-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ianaLanguage: 'en',
+  defaultIanaLanguage: true,
+  ...over,
+});
+
+describe('migrateUriDocument', () => {
+  describe('idempotency', () => {
+    it('returns the input unchanged when no legacy field is present', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          {
+            targetUrl: 'https://example.com/cert',
+            title: 'Cert',
+            linkType: 'gs1:certificationInfo',
+            context: 'us',
+            mimeType: 'application/json',
+            active: true,
+            fwqs: false,
+            defaultLinkType: true,
+            defaultContext: true,
+            defaultMimeType: true,
+            hreflang: ['en-US', 'en'],
+          },
+        ],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [{ linkId: 'lnk-1', action: 'created' }],
+          },
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.mutated).toBe(false);
+      expect(outcome.outputResponseCount).toBe(1);
+      expect(document).toBe(doc);
+    });
+  });
+
+  describe('legacy single-language variants', () => {
+    it('converts ianaLanguage into hreflang[] and strips legacy fields', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [baseLegacyResponse({ ianaLanguage: 'fr' })],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.mutated).toBe(true);
+      expect(document.responses).toHaveLength(1);
+      expect(document.responses[0]).not.toHaveProperty('ianaLanguage');
+      expect(document.responses[0]).not.toHaveProperty('defaultIanaLanguage');
+      expect(document.responses[0].hreflang).toEqual(['fr']);
+    });
+
+    it('preserves an existing hreflang[] and appends the legacy ianaLanguage', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            ianaLanguage: 'en',
+            hreflang: ['en-US'],
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.responses[0].hreflang).toEqual(['en-US', 'en']);
+    });
+
+    it('deduplicates hreflang entries case-insensitively', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            ianaLanguage: 'EN',
+            hreflang: ['en'],
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.responses[0].hreflang).toEqual(['en']);
+    });
+  });
+
+  describe('4-tuple merge', () => {
+    it('merges two legacy variants sharing the new 4-tuple', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-en',
+            ianaLanguage: 'en',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-fr',
+            ianaLanguage: 'fr',
+            createdAt: '2026-01-02T00:00:00.000Z',
+          }),
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.inputResponseCount).toBe(2);
+      expect(outcome.outputResponseCount).toBe(1);
+      expect(document.responses[0].linkId).toBe('lnk-en');
+      expect(document.responses[0].hreflang).toEqual(['en', 'fr']);
+    });
+
+    it('first-registered (by createdAt) wins when metadata diverges', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-old',
+            title: 'Original title',
+            ianaLanguage: 'en',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-new',
+            title: 'Newer title',
+            ianaLanguage: 'fr',
+            createdAt: '2026-02-01T00:00:00.000Z',
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.responses[0].linkId).toBe('lnk-old');
+      expect(document.responses[0].title).toBe('Original title');
+    });
+
+    it('falls back to array order when createdAt is missing on a variant', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-no-ts-a',
+            ianaLanguage: 'en',
+            createdAt: undefined,
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-no-ts-b',
+            ianaLanguage: 'fr',
+            createdAt: undefined,
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.responses[0].linkId).toBe('lnk-no-ts-a');
+      expect(document.responses[0].hreflang).toEqual(['en', 'fr']);
+    });
+
+    it('keeps variants in distinct 4-tuple groups separate', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-us',
+            context: 'us',
+            ianaLanguage: 'en',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-au',
+            context: 'au',
+            ianaLanguage: 'en',
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.responses).toHaveLength(2);
+      const ids = document.responses.map((r) => r.linkId).sort();
+      expect(ids).toEqual(['lnk-au', 'lnk-us']);
+    });
+  });
+
+  describe('default flag re-enforcement', () => {
+    it('removes defaultIanaLanguage and re-runs default-flag enforcement', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-1',
+            ianaLanguage: 'en',
+            defaultIanaLanguage: true,
+            defaultContext: true,
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-2',
+            context: 'au',
+            mimeType: 'text/html',
+            ianaLanguage: 'en',
+            defaultIanaLanguage: true,
+            defaultContext: true,
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      for (const response of document.responses) {
+        expect(response).not.toHaveProperty('defaultIanaLanguage');
+      }
+      // defaultContext is per linkType; only one variant retains it.
+      const defaults = document.responses.filter((r) => r.defaultContext);
+      expect(defaults).toHaveLength(1);
+    });
+  });
+
+  describe('version history rewrite', () => {
+    it('rewrites previousIanaLanguage into previousHreflang as a single-element array', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [baseLegacyResponse({ ianaLanguage: 'fr' })],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [
+              {
+                linkId: 'lnk-1',
+                action: 'updated',
+                previousTargetUrl: 'https://example.com/old-cert',
+                previousIanaLanguage: 'en',
+              },
+            ],
+          },
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.rewrittenVersionEntries).toBe(1);
+      const change: any = document.versionHistory![0].changes[0];
+      expect(change).not.toHaveProperty('previousIanaLanguage');
+      expect(change.previousHreflang).toEqual(['en']);
+      expect(change.previousTargetUrl).toBe('https://example.com/old-cert');
+    });
+
+    it('drops previousIanaLanguage entirely when the legacy value was empty', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [baseLegacyResponse()],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [
+              {
+                linkId: 'lnk-1',
+                action: 'updated',
+                previousIanaLanguage: '   ',
+              },
+            ],
+          },
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      const change: any = document.versionHistory![0].changes[0];
+      expect(change).not.toHaveProperty('previousIanaLanguage');
+      expect(change).not.toHaveProperty('previousHreflang');
+    });
+
+    it('passes through version history changes that have no legacy field', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [baseLegacyResponse()],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [{ linkId: 'lnk-1', action: 'created' }],
+          },
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.rewrittenVersionEntries).toBe(0);
+      expect(document.versionHistory![0].changes[0]).toEqual({
+        linkId: 'lnk-1',
+        action: 'created',
+      });
+    });
+  });
+
+  describe('linkset rebuild', () => {
+    it('rebuilds the linkset from merged responses', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            ianaLanguage: 'en',
+            hreflang: ['en-US'],
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.linkset).toBeDefined();
+      expect(document.linkset!.anchor).toContain(
+        'http://localhost:3000/api/4.0.0/gs1/01/09359502000041',
+      );
+      const certRel = Object.keys(document.linkset!).find((k) =>
+        k.endsWith('/certificationInfo'),
+      );
+      expect(certRel).toBeDefined();
+      const targets = (document.linkset as any)[certRel!];
+      expect(targets[0].hreflang).toEqual(['en-US', 'en']);
+    });
+  });
+
+  describe('predecessor-version history preservation', () => {
+    it('emits predecessor-version link target entries when versionHistory carries previousTargetUrl', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-1',
+            ianaLanguage: 'en',
+          }),
+        ],
+        versionHistory: [
+          {
+            version: 2,
+            updatedAt: '2026-02-01T00:00:00.000Z',
+            changes: [
+              {
+                linkId: 'lnk-1',
+                action: 'updated',
+                previousTargetUrl: 'https://example.com/old-cert',
+                previousIanaLanguage: 'fr',
+              },
+            ],
+          },
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [{ linkId: 'lnk-1', action: 'created' }],
+          },
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      expect(document.versionHistory).toHaveLength(2);
+      expect(document.linkset).toBeDefined();
+      const certRel = Object.keys(document.linkset!).find((k) =>
+        k.endsWith('/certificationInfo'),
+      );
+      const targets: any[] = (document.linkset as any)[certRel!];
+      const predecessor = targets.find(
+        (t) => Array.isArray(t.rel) && t.rel.includes('predecessor-version'),
+      );
+      expect(predecessor).toBeDefined();
+      expect(predecessor.href).toBe('https://example.com/old-cert');
+    });
+  });
+
+  describe('4-tuple case sensitivity', () => {
+    it('treats variants differing only in case as distinct (RFC 3986)', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-lower',
+            targetUrl: 'https://example.com/Cert',
+            ianaLanguage: 'en',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-mixed',
+            targetUrl: 'https://example.com/cert',
+            ianaLanguage: 'en',
+          }),
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.inputResponseCount).toBe(2);
+      expect(outcome.outputResponseCount).toBe(2);
+      expect(outcome.discardedLinkIds).toEqual([]);
+      const ids = document.responses.map((r) => r.linkId).sort();
+      expect(ids).toEqual(['lnk-lower', 'lnk-mixed']);
+    });
+  });
+
+  describe('mixed legacy and non-legacy version-history changes', () => {
+    it('rewrites only the change that carries previousIanaLanguage and leaves siblings alone', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [baseLegacyResponse({ ianaLanguage: 'fr' })],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [
+              { linkId: 'lnk-2', action: 'created' },
+              {
+                linkId: 'lnk-1',
+                action: 'updated',
+                previousIanaLanguage: 'en',
+                previousTargetUrl: 'https://example.com/old-cert',
+              },
+              {
+                linkId: 'lnk-3',
+                action: 'deleted',
+                previousTargetUrl: 'https://example.com/gone',
+              },
+            ],
+          },
+        ],
+      };
+
+      const { document, outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.rewrittenVersionEntries).toBe(1);
+      const entry = document.versionHistory![0];
+      expect(entry.changes).toHaveLength(3);
+      expect(entry.changes[0]).toEqual({ linkId: 'lnk-2', action: 'created' });
+      const updated: any = entry.changes[1];
+      expect(updated.previousHreflang).toEqual(['en']);
+      expect(updated).not.toHaveProperty('previousIanaLanguage');
+      expect(updated.previousTargetUrl).toBe('https://example.com/old-cert');
+      const deleted: any = entry.changes[2];
+      expect(deleted).toEqual({
+        linkId: 'lnk-3',
+        action: 'deleted',
+        previousTargetUrl: 'https://example.com/gone',
+      });
+    });
+  });
+
+  describe('response field pass-through', () => {
+    it('keeps unrelated fields (accessRole, public, etc.) intact across migration', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            ianaLanguage: 'en',
+            accessRole: ['supplier', 'auditor'],
+            public: false,
+            rel: 'gs1:certificationInfo',
+            decryptionKey: 'k-xyz',
+          }),
+        ],
+      };
+
+      const { document } = migrateUriDocument(doc, attrs);
+
+      const r: any = document.responses[0];
+      expect(r.accessRole).toEqual(['supplier', 'auditor']);
+      expect(r.public).toBe(false);
+      expect(r.rel).toBe('gs1:certificationInfo');
+      expect(r.decryptionKey).toBe('k-xyz');
+    });
+  });
+
+  describe('discarded link-id tracking', () => {
+    it('records discarded variant linkIds for caller orphan-index cleanup', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          baseLegacyResponse({
+            linkId: 'lnk-keep',
+            ianaLanguage: 'en',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-drop-a',
+            ianaLanguage: 'fr',
+            createdAt: '2026-01-02T00:00:00.000Z',
+          }),
+          baseLegacyResponse({
+            linkId: 'lnk-drop-b',
+            ianaLanguage: 'de',
+            createdAt: '2026-01-03T00:00:00.000Z',
+          }),
+        ],
+      };
+
+      const { outcome, document } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.outputResponseCount).toBe(1);
+      expect(document.responses[0].linkId).toBe('lnk-keep');
+      expect(outcome.discardedLinkIds.sort()).toEqual([
+        'lnk-drop-a',
+        'lnk-drop-b',
+      ]);
+    });
+  });
+
+  describe('detection of legacy fields', () => {
+    it('treats a doc with only legacy version-history fields as in need of migration', () => {
+      const doc: any = {
+        ...baseLegacyDoc(),
+        responses: [
+          {
+            targetUrl: 'https://example.com/cert',
+            title: 'Cert',
+            linkType: 'gs1:certificationInfo',
+            context: 'us',
+            mimeType: 'application/json',
+            active: true,
+            fwqs: false,
+            defaultLinkType: true,
+            defaultContext: true,
+            defaultMimeType: true,
+            hreflang: ['en'],
+          },
+        ],
+        versionHistory: [
+          {
+            version: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            changes: [
+              {
+                linkId: 'lnk-1',
+                action: 'updated',
+                previousIanaLanguage: 'fr',
+              },
+            ],
+          },
+        ],
+      };
+
+      const { outcome } = migrateUriDocument(doc, attrs);
+
+      expect(outcome.mutated).toBe(true);
+      expect(outcome.rewrittenVersionEntries).toBe(1);
+    });
+  });
+});

--- a/app/src/migration/v4-transform.ts
+++ b/app/src/migration/v4-transform.ts
@@ -1,0 +1,374 @@
+import { recalculateDefaultFlags } from '../modules/link-registration/utils/default-flags.utils';
+import { constructLinkSetJson } from '../modules/link-registration/utils/link-set.utils';
+import {
+  LinkChange,
+  Uri,
+  VersionHistoryEntry,
+} from '../modules/link-resolution/interfaces/uri.interface';
+
+/**
+ * Legacy (pre-#120) response shape: variants carried a scalar `ianaLanguage`
+ * and a per-variant `defaultIanaLanguage` boolean. The new model drops both
+ * in favour of an `hreflang: string[]` array on each variant.
+ */
+type LegacyLinkResponse = {
+  targetUrl: string;
+  title?: string;
+  linkType: string;
+  context: string;
+  mimeType: string;
+  active?: boolean;
+  fwqs?: boolean;
+  defaultLinkType?: boolean;
+  defaultContext?: boolean;
+  defaultMimeType?: boolean;
+  linkId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  encryptionMethod?: string;
+  accessRole?: string[];
+  method?: string;
+  public?: boolean;
+  rel?: string[];
+  hreflang?: string[];
+  ianaLanguage?: string;
+  defaultIanaLanguage?: boolean;
+};
+
+type LegacyLinkChange = LinkChange & { previousIanaLanguage?: string };
+
+type LegacyVersionHistoryEntry = {
+  version: number;
+  updatedAt: string;
+  changes: LegacyLinkChange[];
+};
+
+type LegacyUri = Omit<Uri, 'responses' | 'versionHistory'> & {
+  responses: LegacyLinkResponse[];
+  versionHistory?: LegacyVersionHistoryEntry[];
+};
+
+/**
+ * Summary of one migration applied to a single URI document.
+ */
+export interface MigrationOutcome {
+  /** `true` if any field of the input doc was mutated. */
+  mutated: boolean;
+  /** Source response count before the merge. */
+  inputResponseCount: number;
+  /** Response count after the 4-tuple merge. */
+  outputResponseCount: number;
+  /** Number of versionHistory entries rewritten (legacy → hreflang). */
+  rewrittenVersionEntries: number;
+  /**
+   * `linkId`s that existed on a source variant but did not survive the
+   * 4-tuple merge. Callers should clean up the corresponding
+   * `_index/links/<linkId>.json` index entries so post-migration lookups
+   * by these linkIds fail fast rather than leaving orphan index files.
+   */
+  discardedLinkIds: string[];
+}
+
+/**
+ * Migrate a single URI document from the legacy 5-tuple key model
+ * (`targetUrl, linkType, mimeType, ianaLanguage, context`) to the v4 4-tuple
+ * model (`targetUrl, linkType, mimeType, context`) with a merged
+ * `hreflang: string[]` array per variant.
+ *
+ * Idempotent: a document already in 4-tuple shape returns
+ * `{ mutated: false, ... }` and the input doc is returned unchanged.
+ *
+ * Conflict resolution (when two legacy variants share the new 4-tuple but
+ * disagree on other metadata): **first-registered wins** by `createdAt`.
+ * Variants without `createdAt` sort after timestamped variants; ties
+ * (both timestamped equal, or both untimestamped) preserve original
+ * registration order via a stable sort. Discarded variants' `ianaLanguage`
+ * values are unioned into the survivor's `hreflang[]`. Discarded
+ * variants' `linkId`s are dropped from the document; their identifiers
+ * are returned in {@link MigrationOutcome.discardedLinkIds} so the
+ * caller can delete the corresponding `_index/links/<linkId>.json`
+ * orphan files. The merge does NOT append a synthetic version-history
+ * entry; the only audit signal is the post-migration `discardedLinkIds`
+ * report.
+ *
+ * Side effects on the returned document:
+ * - Removes `ianaLanguage` and `defaultIanaLanguage` fields from every
+ *   response (both gone in the v4 model).
+ * - Rewrites `versionHistory[].changes[].previousIanaLanguage` to
+ *   `previousHreflang: [previousIanaLanguage]`.
+ * - Re-runs `recalculateDefaultFlags` so the v4 scopes (per linkType for
+ *   `defaultContext`, per linkType + context for `defaultMimeType`) hold.
+ * - Rebuilds `linkset` from the merged responses via
+ *   `constructLinkSetJson`, passing the rewritten `versionHistory` so
+ *   `predecessor-version` link target entries are preserved.
+ *
+ * The 4-tuple key is **case-sensitive** on every component
+ * (`targetUrl, linkType, mimeType, context`), matching the live
+ * `buildResponseKey` in `link-registration/utils/upsert.utils.ts` and
+ * RFC 3986 §6.2.2.1 path-segment semantics. Two variants whose only
+ * difference is letter case on any of those four fields are treated as
+ * distinct records by the migration, same as by the live registration
+ * service.
+ *
+ * @param input The stored URI document (may already be in v4 shape).
+ * @param attrs Resolver attributes needed to rebuild the linkset.
+ * @returns A tuple of the migrated document (or the original if no-op)
+ *   and a {@link MigrationOutcome} describing what changed.
+ */
+export function migrateUriDocument(
+  input: LegacyUri,
+  attrs: { resolverDomain: string; linkTypeVocDomain: string },
+): { document: Uri; outcome: MigrationOutcome } {
+  const responses = Array.isArray(input.responses) ? input.responses : [];
+  const versionHistory = Array.isArray(input.versionHistory)
+    ? input.versionHistory
+    : undefined;
+
+  const hasLegacyResponseField = responses.some(
+    (r) => 'ianaLanguage' in r || 'defaultIanaLanguage' in r,
+  );
+  const hasLegacyVersionField = versionHistory?.some((entry) =>
+    entry.changes.some((change) => 'previousIanaLanguage' in change),
+  );
+
+  if (!hasLegacyResponseField && !hasLegacyVersionField) {
+    return {
+      document: input as unknown as Uri,
+      outcome: {
+        mutated: false,
+        inputResponseCount: responses.length,
+        outputResponseCount: responses.length,
+        rewrittenVersionEntries: 0,
+        discardedLinkIds: [],
+      },
+    };
+  }
+
+  const { merged: mergedResponses, discardedLinkIds } =
+    mergeResponsesByFourTuple(responses);
+  recalculateDefaultFlags(mergedResponses as any);
+
+  const { entries, rewrittenCount } = rewriteVersionHistory(versionHistory);
+
+  const aiCode = deriveAiCode(input.id, input.namespace);
+  const linksetInput = {
+    namespace: input.namespace,
+    identificationKeyType: input.identificationKeyType,
+    identificationKey: input.identificationKey,
+    qualifierPath: input.qualifierPath,
+    active: input.active,
+    description: input.description,
+    responses: mergedResponses.filter((r) => r.active !== false) as any,
+  };
+  // `versionHistory` (post-rewrite) is passed so `constructLinkSetJson`
+  // emits `predecessor-version` link target entries for any change with
+  // a `previousTargetUrl`. Omitting it silently dropped predecessor
+  // links from the rebuilt linkset until the next live update.
+  const linkset = constructLinkSetJson(linksetInput, aiCode, attrs, entries);
+
+  const document: Uri = {
+    ...input,
+    responses: mergedResponses as any,
+    linkset,
+    versionHistory: entries,
+  };
+
+  return {
+    document,
+    outcome: {
+      mutated: true,
+      inputResponseCount: responses.length,
+      outputResponseCount: mergedResponses.length,
+      rewrittenVersionEntries: rewrittenCount,
+      discardedLinkIds,
+    },
+  };
+}
+
+/**
+ * Groups legacy responses by the new v4 4-tuple
+ * (`targetUrl, linkType, mimeType, context`) and merges each group into a
+ * single response. Within a group, the **first-registered** variant (by
+ * `createdAt`; untimestamped variants sort after timestamped ones; ties
+ * preserve original registration order via a stable sort) becomes the
+ * canonical record; the others contribute their `ianaLanguage` values
+ * to the merged `hreflang[]` array.
+ *
+ * Discarded variants' other metadata (titles, flags, accessRole, etc.)
+ * is NOT preserved. Their `linkId`s are collected in the returned
+ * `discardedLinkIds` array so the caller can delete the corresponding
+ * `_index/links/<linkId>.json` orphan files; no synthetic version
+ * history entry is appended. Operators with divergent metadata on
+ * otherwise-identical 4-tuple variants should reconcile those manually
+ * before migrating (see the v4 migration guide).
+ */
+function mergeResponsesByFourTuple(responses: LegacyLinkResponse[]): {
+  merged: LegacyLinkResponse[];
+  discardedLinkIds: string[];
+} {
+  const groups = new Map<string, LegacyLinkResponse[]>();
+  for (const response of responses) {
+    const key = fourTupleKey(response);
+    const group = groups.get(key) ?? [];
+    group.push(response);
+    groups.set(key, group);
+  }
+
+  const merged: LegacyLinkResponse[] = [];
+  const discardedLinkIds: string[] = [];
+  for (const group of groups.values()) {
+    if (group.length === 1) {
+      merged.push(stripLegacyFields(group[0], collectHreflangTags(group)));
+      continue;
+    }
+
+    const sorted = [...group].sort(compareByCreatedAt);
+    const survivor = stripLegacyFields(sorted[0], collectHreflangTags(group));
+    const discarded = sorted.slice(1);
+
+    if (discarded.length) {
+      survivor.updatedAt = survivor.updatedAt ?? new Date().toISOString();
+      for (const variant of discarded) {
+        if (variant.linkId && variant.linkId !== survivor.linkId) {
+          discardedLinkIds.push(variant.linkId);
+        }
+      }
+    }
+
+    merged.push(survivor);
+  }
+
+  return { merged, discardedLinkIds };
+}
+
+/**
+ * Removes the legacy `ianaLanguage` and `defaultIanaLanguage` fields from
+ * a response and replaces them with the merged `hreflang[]` value.
+ */
+function stripLegacyFields(
+  response: LegacyLinkResponse,
+  hreflang: string[],
+): LegacyLinkResponse {
+  const {
+    ianaLanguage: _ianaLanguage,
+    defaultIanaLanguage: _defaultIanaLanguage,
+    ...rest
+  } = response;
+  void _ianaLanguage;
+  void _defaultIanaLanguage;
+  return { ...rest, hreflang };
+}
+
+/**
+ * Collects the merged `hreflang[]` for a group: union of each variant's
+ * existing `hreflang` (if any) and its legacy `ianaLanguage` (if any),
+ * deduplicated case-insensitively while preserving first-seen casing.
+ * Returns the array in stable order: existing tags from the
+ * first-registered survivor first, then legacy `ianaLanguage` values in
+ * the order of the discarded variants.
+ */
+function collectHreflangTags(group: LegacyLinkResponse[]): string[] {
+  const seen = new Map<string, string>();
+  for (const response of group) {
+    for (const tag of response.hreflang ?? []) {
+      const key = tag.toLowerCase();
+      if (!seen.has(key)) {
+        seen.set(key, tag);
+      }
+    }
+  }
+  for (const response of group) {
+    const legacy = response.ianaLanguage?.trim();
+    if (!legacy) continue;
+    const key = legacy.toLowerCase();
+    if (!seen.has(key)) {
+      seen.set(key, legacy);
+    }
+  }
+  return Array.from(seen.values());
+}
+
+/**
+ * Rewrites the version history so that each legacy
+ * `previousIanaLanguage` scalar becomes a `previousHreflang: [value]`
+ * single-element array on the same change record. An empty or
+ * whitespace-only `previousIanaLanguage` is dropped (no
+ * `previousHreflang` field added), matching the live registration
+ * behaviour. Other change fields are passed through unchanged. Returns
+ * the new entries plus a count of how many records were touched.
+ */
+function rewriteVersionHistory(
+  versionHistory: LegacyVersionHistoryEntry[] | undefined,
+): { entries: VersionHistoryEntry[] | undefined; rewrittenCount: number } {
+  if (!versionHistory) {
+    return { entries: undefined, rewrittenCount: 0 };
+  }
+  let rewrittenCount = 0;
+  const entries = versionHistory.map((entry) => {
+    const changes = entry.changes.map((change) => {
+      if (!('previousIanaLanguage' in change)) {
+        return change;
+      }
+      rewrittenCount += 1;
+      const { previousIanaLanguage, ...rest } = change;
+      const value = previousIanaLanguage?.trim();
+      if (!value) {
+        return rest as LinkChange;
+      }
+      return { ...rest, previousHreflang: [value] } as LinkChange;
+    });
+    return { ...entry, changes };
+  });
+  return { entries, rewrittenCount };
+}
+
+function fourTupleKey(response: LegacyLinkResponse): string {
+  return [
+    response.targetUrl,
+    response.linkType,
+    response.mimeType,
+    response.context,
+  ]
+    .map((segment) => segment ?? '')
+    .join('|');
+}
+
+/**
+ * Orders variants oldest-first by `createdAt`. Untimestamped variants
+ * sort after timestamped ones so a real `createdAt` always wins
+ * "first-registered". Ties (including untimestamped vs untimestamped)
+ * fall back to the stable sort's original order.
+ */
+function compareByCreatedAt(
+  a: LegacyLinkResponse,
+  b: LegacyLinkResponse,
+): number {
+  const aCreated = a.createdAt ? Date.parse(a.createdAt) : NaN;
+  const bCreated = b.createdAt ? Date.parse(b.createdAt) : NaN;
+  if (Number.isFinite(aCreated) && Number.isFinite(bCreated)) {
+    return aCreated - bCreated;
+  }
+  if (Number.isFinite(aCreated)) return -1;
+  if (Number.isFinite(bCreated)) return 1;
+  return 0;
+}
+
+/**
+ * Recovers the AI code from a stored document's `id` so the rebuilt
+ * linkset's anchor lines up with the v4 URL structure
+ * (`{namespace}/{aiCode}/{identificationKey}[/qualifierPath]`).
+ *
+ * Stored IDs follow the pattern `{namespace}/{aiCode}/{rest}` where
+ * `{rest}` is the identificationKey (optionally followed by a qualifier
+ * path). The aiCode is the second path segment.
+ */
+function deriveAiCode(id: string, namespace: string): string {
+  if (!id) return '';
+  const trimmed = id.endsWith('.json') ? id.slice(0, -'.json'.length) : id;
+  const prefix = `${namespace}/`;
+  const withoutNamespace = trimmed.startsWith(prefix)
+    ? trimmed.slice(prefix.length)
+    : trimmed;
+  const [aiCode] = withoutNamespace.split('/');
+  return aiCode ?? '';
+}

--- a/app/src/modules/link-resolution/interfaces/uri.interface.ts
+++ b/app/src/modules/link-resolution/interfaces/uri.interface.ts
@@ -32,6 +32,7 @@ export interface LinkChange {
   previousLinkType?: string;
   previousMimeType?: string;
   previousContext?: string;
+  previousHreflang?: string[];
 }
 
 export interface VersionHistoryEntry {

--- a/app/src/repository/providers/minio/minio.provider.spec.ts
+++ b/app/src/repository/providers/minio/minio.provider.spec.ts
@@ -89,6 +89,43 @@ describe('MinioProvider', () => {
     ]);
   });
 
+  it('lists objects recursively under the given prefix', async () => {
+    const listSpy = jest
+      .spyOn(minioClient, 'listObjects')
+      .mockImplementation(() => [] as any);
+
+    await provider.all('users');
+
+    expect(listSpy).toHaveBeenCalledWith('test', 'users', true);
+  });
+
+  it('skips folder-style entries that have no name when listing', async () => {
+    jest.spyOn(minioClient, 'listObjects').mockImplementation(() => {
+      return [
+        { name: 'users/a.json' },
+        { prefix: 'users/sub/' } as any,
+        { name: 'users/sub/b.json' },
+      ] as any;
+    });
+
+    jest.spyOn(minioClient, 'getObject').mockImplementation((_, objectName) => {
+      const promise = new Promise<Readable>((resolve) => {
+        const stream = new Readable();
+        stream.push(JSON.stringify({ id: String(objectName) }));
+        stream.push(null);
+        resolve(stream);
+      });
+      return promise;
+    });
+
+    const results = await provider.all<{ id: string }>('users');
+
+    expect(results.map((r) => r.id).sort()).toEqual([
+      'users/a.json',
+      'users/sub/b.json',
+    ]);
+  });
+
   it('should delete an item by ID', async () => {
     const id = 'test.json';
     jest

--- a/app/src/repository/providers/minio/minio.provider.ts
+++ b/app/src/repository/providers/minio/minio.provider.ts
@@ -69,13 +69,19 @@ export class MinioProvider implements IRepositoryProvider {
   }
 
   async all<T>(category: string): Promise<T[]> {
+    // Recursive listing: surfaces every object under the prefix, not just
+    // direct children. Without `recursive=true`, hierarchical prefixes are
+    // returned as folder entries (no `.name`), which both breaks
+    // `this.one(undefined)` below and hides nested objects.
     const dataStream = this.minioClient.listObjects(
       this.options.bucket,
       category,
+      true,
     );
     const data: T[] = [];
 
     for await (const obj of dataStream) {
+      if (!obj?.name) continue;
       const singleData = await this.one<T>(obj.name);
       if (singleData) {
         data.push(singleData);

--- a/documentation/docs/contributing/index.md
+++ b/documentation/docs/contributing/index.md
@@ -92,8 +92,7 @@ The example files provide sensible defaults for local development:
 | `OBJECT_STORAGE_BUCKET_NAME` | `idr-bucket` | Bucket name (use `idr-bucket-test` for test env) |
 | `OBJECT_STORAGE_PATH_STYLE` | `true` | Required for local MinIO |
 | `IDENTIFIER_PATH` | `identifiers` | Path for identifier operations |
-| `RESOLVER_DOMAIN` | `http://localhost:3000/api/v4` | Base resolver URL |
-| `LINK_TYPE_VOC_DOMAIN` | `http://localhost:3000/api/v4/voc` | Link type vocabulary URL |
+| `RESOLVER_DOMAIN` | `http://localhost:3000` | Base resolver URL (no path, no trailing slash). The service appends `/api/v4` internally. |
 | `API_KEY` | `test123` | API key for authenticated endpoints |
 | `APP_NAME` | `IDR` | Application name |
 | `PORT` | `3000` | Server port |

--- a/documentation/docs/migration-guides/v4.md
+++ b/documentation/docs/migration-guides/v4.md
@@ -1,0 +1,198 @@
+---
+sidebar_position: 3
+title: 3.x to 4.0.0
+---
+
+# Migrating from 3.x to 4.0.0
+
+:::warning Back up your data before upgrading
+This update **rewrites** every stored document to align with the new UNTP v0.7 link variant model. The migration is idempotent and reversible only via your backup. Once you have completed step 7 (start the v4 service) and the service has begun accepting new registrations, rolling back to v3 requires restoring from the backup.
+
+**Before proceeding**, take a full snapshot of your object storage bucket. Use whatever mechanism your storage provider supports (a local filesystem copy for self-hosted MinIO, an S3 versioning snapshot or `aws s3 sync` to a separate bucket, a GCS object versioning toggle, an Azure Blob soft delete, etc.). Keep the snapshot until you have confirmed the upgrade is stable.
+:::
+
+This guide covers what changed between 3.x and 4.0.0, the data migration step you must run between the two versions, and the new behaviour you can expect after the upgrade.
+
+## What changed
+
+v4.0.0 aligns the IDR with [UNTP Identity Resolver v0.7](https://untp.unece.org/docs/specification/IdentityResolver). The biggest change is to the link variant data model.
+
+### Composite key reduced from 5-tuple to 4-tuple
+
+Before v4, each link variant was uniquely identified by `(targetUrl, linkType, mimeType, ianaLanguage, context)`. The scalar `ianaLanguage` field has been retired in favour of a `hreflang: string[]` array on each variant, so the composite key is now `(targetUrl, linkType, mimeType, context)`.
+
+A single variant can now advertise multiple BCP 47 language tags via its `hreflang[]` array, matching the UNTP LinksetSchema target shape.
+
+### Resolver matches against `hreflang[]` membership
+
+The resolver's language-aware cascade was rebuilt against `hreflang[]` membership. The client's `Accept-Language` tags are matched (case-insensitively per RFC 4647 §2.1) against each variant's `hreflang[]` array. BCP 47 lookup fallback (e.g. matching `en-GB` against a variant tagged `en`) is not yet implemented and is tracked in [pyx-industries/pyx-identity-resolver#117](https://github.com/pyx-industries/pyx-identity-resolver/issues/117).
+
+The retired fields are:
+
+- `ianaLanguage` on each link variant.
+- `defaultIanaLanguage` boolean flag on each link variant.
+- The `?ianaLanguage` query parameter on `GET /resolver/links` (re-added as `?hreflang`).
+
+### `defaultContext` is now a pure fallback
+
+`defaultContext: true` no longer participates in the language-aware front tiers of the cascade. It is consulted only when the requested language fails to match any variant. The publisher's "canonical default variant for the link type" semantics are preserved.
+
+### `defaultMimeType` scope is unchanged
+
+`defaultMimeType` is still scoped per `(linkType + context)` at registration time. Resolution does not consult `context` at request time (no request-side context signal), so the cascade returns the first hreflang-matching variant whose flag is set. See the [How It Works](../understanding-the-service/how-it-works) precedence table for the full cascade.
+
+## Before you upgrade
+
+### 1. Stop the v3 service
+
+Stop traffic against the resolver before taking the backup. The migration assumes the bucket is not being mutated while it runs.
+
+### 2. Back up your object storage bucket
+
+Use whatever backup mechanism your storage provider offers. The migration is destructive in the sense that it overwrites each migrated document in place; without a backup, there is no rollback path.
+
+Keep the backup until you have confirmed the v4 service is healthy.
+
+### 3. Pull the v4 container image
+
+```bash
+docker pull pyx-identity-resolver:4.0.0
+```
+
+### 4. Update `RESOLVER_DOMAIN` and remove `API_BASE_URL`
+
+In v4, `RESOLVER_DOMAIN` is the externally-reachable **base URL only** (scheme + host, no path, no trailing slash). The service appends the API path prefix (`/api/v4`) internally based on `apiVersion` in `version.json`. Drop the `/api/3.0.0` segment from your existing value:
+
+```
+# Before (v3)
+RESOLVER_DOMAIN=https://resolver.example.com/api/3.0.0
+
+# After (v4)
+RESOLVER_DOMAIN=https://resolver.example.com
+```
+
+If you previously set `API_BASE_URL` (for Swagger external-server resolution), remove it. `RESOLVER_DOMAIN` now serves both roles.
+
+`LINK_TYPE_VOC_DOMAIN` is not an env var in v4. The link-type vocabulary URL is derived from `RESOLVER_DOMAIN` + the API path prefix + `/voc`, and can be overridden per identifier by setting `namespaceURI` on the identifier record.
+
+The migration uses these values to rebuild every document's pre-computed linkset with the new URL shape.
+
+## Run the migration
+
+### 5. Dry-run first
+
+Run the migration in dry-run mode to see what would change without writing anything:
+
+```bash
+docker run --rm --env-file .env pyx-identity-resolver:4.0.0 \
+  yarn migrate:v4 --dry-run --verbose
+```
+
+The command prints one line per scanned document, e.g.:
+
+```
+[would-migrate] gs1/01/09359502000041: 3 variants → 1 (merged 2); 2 version entries rewritten
+[noop] gs1/01/09359502000042: already in v4 shape
+```
+
+Followed by a summary:
+
+```
+Scanned:  124
+Migrated: 117 (dry-run)
+No-ops:   7
+Failed:   0
+```
+
+Review the output. Pay attention to any `[would-migrate]` line where the input/output variant counts differ — that indicates a **merge**. The merge rule is **first-registered wins** (by `createdAt`): the oldest variant's `linkId`, `title`, and other metadata become the merged record's; the discarded variants' `ianaLanguage` values are unioned into the merged record's `hreflang[]`.
+
+If you have variants that share the new 4-tuple but disagree on other metadata (e.g. different `title` strings, divergent `accessRole` arrays), the merge will silently keep the first-registered variant's values and discard the rest. Either reconcile the divergence manually before running the real migration, or accept the first-registered-wins outcome.
+
+### 6. Run the real migration
+
+When you are satisfied with the dry-run output, run without `--dry-run`:
+
+```bash
+docker run --rm --env-file .env pyx-identity-resolver:4.0.0 \
+  yarn migrate:v4
+```
+
+The migration aborts on the first per-document failure by default so the failure is not buried in a long log. Pass `--continue-on-error` to migrate as many documents as possible and review the failures at the end.
+
+To re-run on a single document by id (useful when iterating on a failure):
+
+```bash
+docker run --rm --env-file .env pyx-identity-resolver:4.0.0 \
+  yarn migrate:v4 --only gs1/01/09359502000041
+```
+
+The migration is **idempotent**: re-running on a document that is already in v4 shape is a no-op. If the migration fails partway through (process killed, object storage timeout, etc.), re-run from the start; already-migrated documents are skipped.
+
+### 7. Start the v4 service
+
+Once the migration reports `Failed: 0`, start the v4 service against the migrated bucket.
+
+### 8. Recovery if anything goes wrong
+
+If the migration produces unexpected results or the v4 service does not behave as expected, restore your object storage bucket from the backup taken in step 2 and re-deploy the v3 service. Then investigate the migration output and file an issue.
+
+## After the upgrade
+
+### `listLinks` query: `ianaLanguage` is now `hreflang`
+
+The `GET /resolver/links?ianaLanguage=<tag>` query parameter has been replaced with `?hreflang=<tag>`. Both accept a single BCP 47 tag. The filter returns responses whose `hreflang[]` array contains the supplied tag.
+
+```bash
+# v3
+curl "https://resolver.example.com/api/3.0.0/resolver/links?namespace=gs1&identificationKeyType=gtin&identificationKey=12345678901234&ianaLanguage=en"
+
+# v4
+curl "https://resolver.example.com/api/v4/resolver/links?namespace=gs1&identificationKeyType=gtin&identificationKey=12345678901234&hreflang=en"
+```
+
+### Registration payloads
+
+`ianaLanguage` and `defaultIanaLanguage` are no longer accepted on the registration payload. Replace them with `hreflang: string[]` on each variant.
+
+```json
+// v3
+{
+  "linkType": "gs1:certificationInfo",
+  "ianaLanguage": "en",
+  "defaultIanaLanguage": true,
+  "context": "au",
+  "mimeType": "text/html"
+}
+
+// v4
+{
+  "linkType": "gs1:certificationInfo",
+  "hreflang": ["en-AU", "en"],
+  "context": "au",
+  "mimeType": "text/html"
+}
+```
+
+A publisher who wants region-specific routing should include the regional subtag in `hreflang[]` (e.g. `["en-AU"]`). The resolver does not perform BCP 47 lookup fallback yet (tracked in [pyx-industries/pyx-identity-resolver#117](https://github.com/pyx-industries/pyx-identity-resolver/issues/117)), so a request for `en-AU` will not match a variant tagged only `["en"]`.
+
+## Checklist
+
+### Required before upgrade
+
+- [ ] Stop the v3 service.
+- [ ] Back up your object storage bucket.
+- [ ] Update `RESOLVER_DOMAIN` to the base URL only (drop the `/api/3.0.0` suffix) and remove `API_BASE_URL` if previously set.
+- [ ] Pull the `4.0.0` container image.
+- [ ] Run the migration in `--dry-run` mode and review the output.
+- [ ] Reconcile any documents where divergent metadata would be lost by the first-registered-wins merge rule.
+
+### Required during upgrade
+
+- [ ] Run the migration (`yarn migrate:v4`) and confirm `Failed: 0`.
+- [ ] Start the v4 service.
+
+### Recommended after upgrade
+
+- [ ] Update registration scripts to send `hreflang: string[]` instead of `ianaLanguage`.
+- [ ] Update API clients to use the new `?hreflang=<tag>` query parameter on `listLinks`.
+- [ ] Update consumers that rely on `Accept-Language` matching to send proper BCP 47 tags (e.g. `en-AU`) that exactly match a variant's `hreflang[]` entry.


### PR DESCRIPTION
This PR delivers issue #109. It migrates stored URI documents from the legacy 5-tuple key model `(targetUrl, linkType, mimeType, ianaLanguage, context)` to the v4 4-tuple model with merged `hreflang[]` arrays.

The migration is a CLI command (`yarn migrate:v4`) that operators run between stopping v3 and starting v4. Conflict resolution is first-registered-by-`createdAt` wins; the discarded variants' `ianaLanguage` values are unioned into the survivor's `hreflang[]`. The migration is idempotent so it can be safely re-run on a partially-migrated bucket.

The 4-tuple key is case-sensitive on every component, matching the live `buildResponseKey` and RFC 3986 path-segment semantics. After each document is migrated, the CLI deletes `_index/links/{linkId}.json` for every variant `linkId` that did not survive the merge, so post-migration lookups by those linkIds fail fast rather than leaving orphan index files. Per-identifier `linkTypeVocDomain` is sourced from each identifier record's `namespaceURI`, falling back to `{apiBaseUrl}/voc` when no override is set.

The operator-facing guide is at [documentation/docs/migration-guides/v4.md](documentation/docs/migration-guides/v4.md). Conflict-resolution rules, dry-run instructions, and recovery steps are covered there. The composition of the resolver base URL uses the shared `buildApiBaseUrl` helper introduced in #125, so migrated linkset anchors match what the live services emit.

Closes #109

## Test plan
- [x] Unit suite (557 passing). New specs across `v4-transform.spec.ts` (idempotency, single-language conversion, 4-tuple merge, first-registered-wins, version-history rewrite, default-flag re-enforcement, linkset rebuild, predecessor-version preservation, case-sensitive 4-tuple, mixed legacy/non-legacy history changes, response field pass-through, discarded link-id tracking) and `v4-cli.utils.spec.ts` (parseArgs option matrix, error paths, describeOutcome formatting). Plus 2 new MinIO provider specs for recursive listing and folder-entry skipping.
- [x] Build (TypeScript + Nest compile).
- [x] Lint.
- [x] Manual smoke against a seeded MinIO bucket containing both legacy and v4-shape docs: dry-run, real run, idempotent re-run, `--only <id>`, unknown-id failure.
- [ ] CI e2e suite to confirm no regression elsewhere.
