### PR TITLE
docs(v4): fill in missing variant field coverage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,16 @@ The API URL path now carries only the major version. The base path moves from `/
 
 `RESOLVER_DOMAIN` is now the externally-reachable base URL only (scheme + host, no path, no trailing slash). The service appends `/api/v4` internally. `API_BASE_URL` and `LINK_TYPE_VOC_DOMAIN` are retired; `RESOLVER_DOMAIN` is the single source of truth, and the link-type vocabulary base can be overridden per identifier by setting `namespaceURI` on the identifier record.
 
+#### Additive variant fields and MIME loosening
+
+These are additive and do not require operator action; publishers can opt in once on v4.
+
+- **`public: boolean`** on each variant. Indicates the URL itself is safe to publish in a public directory. Distinct from `accessRole` and `encryptionMethod`, which govern who may *retrieve or decrypt* the resource.
+- **`rel: string[]`** on each variant. Carries additional link relation types qualifying the variant beyond its primary `linkType`. The reserved value `predecessor-version` is silently stripped from publisher input; the server emits it itself on predecessor entries derived from version history.
+- **MIME type loosening.** The service now accepts any RFC 6838 well-formed media type (including custom and vendor-prefixed types such as `application/vnd.acme.sbom+json`); v3 rejected anything outside a curated list.
+
+The full per-variant field reference, including pre-existing fields that were under-documented in earlier versions, lives in the [Developer Guide](./documentation/docs/developer-guide/index.md#variant-fields).
+
 ### Data migration
 
 v4 ships a one-shot CLI command (`yarn migrate:v4`) that operators

--- a/documentation/docs/developer-guide/index.md
+++ b/documentation/docs/developer-guide/index.md
@@ -178,9 +178,11 @@ Each registration targets a namespace + identifier key type + identifier key
 (and optionally a qualifier path),
 and contains one or more **responses** --
 each pointing to a different URL with its own link type,
-language tag (e.g., `en`, `fr-CA`),
+language tags (BCP 47 entries in `hreflang[]` such as `en`, `en-AU`, or `fr-CA`),
 MIME type (the content format, such as `text/html` or `application/pdf`),
 and context (typically a geographic region code such as `au` or `us`).
+The full set of accepted per-variant fields is summarised under
+[Variant fields](#variant-fields) below.
 
 ### Register links
 
@@ -237,11 +239,37 @@ A successful `201` response:
 }
 ```
 
-:::note Deprecation notice
-The `description` field replaces the deprecated `itemDescription` field.
-Both are accepted for backwards compatibility, but `description` is preferred.
-`itemDescription` will be removed in v3.0.
+:::note `description` field
+The top-level `description` field replaces the legacy `itemDescription` field.
+Both are accepted for backwards compatibility, but `description` is preferred;
+`itemDescription` was deprecated in v3.0.0 and remains accepted as an alias.
 :::
+
+#### Variant fields
+
+Every entry in the `responses[]` array (a "variant") accepts the following fields. The full Swagger UI at `/api` is generated from the same DTOs and is the authoritative source for shape and validation.
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `linkType` | string | yes | The link relation type (`prefix:key`, e.g. `acme:sustainabilityInfo`). Validated against the vocabulary for the namespace's prefix. |
+| `title` | string | yes | Human-readable label for the link. |
+| `targetUrl` | string (URL) | yes | The URL the link resolves to. |
+| `mimeType` | string | yes | Any RFC 6838 well-formed media type (e.g. `text/html`, `application/pdf`, `application/vnd.acme.sbom+json`). Custom and vendor-prefixed types are accepted; the value is not constrained to a registry. |
+| `context` | string | yes | Context qualifier (typically a regional code such as `au`, `us`, or `eu`). Part of the composite key. |
+| `hreflang` | string[] | no | BCP 47 language tags advertised by this variant. A single variant can serve multiple tags. Matching is case-insensitive per RFC 4647 §2.1. |
+| `defaultLinkType` | boolean | yes | Marks this variant as the default for resolution requests that omit `linkType`. Only one variant per registration may set this to `true`. |
+| `defaultContext` | boolean | yes | Marks this variant as the publisher's canonical fallback for its link type when no variant matches the requested language. Only one variant per link type may set this to `true`. |
+| `defaultMimeType` | boolean | yes | Marks this variant as the preferred MIME type within its `(linkType, context)` group. Only one variant per `(linkType, context)` may set this to `true`. |
+| `fwqs` | boolean | yes | Forward query string flag (see [`fwqs`](#forward-query-string-fwqs) above). |
+| `active` | boolean | yes | Whether the variant is served at resolution time. Set to `false` on soft delete; remains in the document but is omitted from the linkset. |
+| `accessRole` | string[] | no | UNTP access roles that may retrieve this variant under variant-based disclosure. Values follow the URI pattern `untp:accessRole#RoleName` (`Anonymous`, `Customer`, `Regulator`, `Recycler`, `Auditor`, `Owner`); shorthand forms such as `customer` are expanded at resolution time. |
+| `encryptionMethod` | string | no | Encryption applied to the target content. One of `none`, `AES-128`, `AES-256`. Documents the encryption scheme; the resolver does not perform decryption itself (see `fwqs` + `decryptionKey` for key forwarding). |
+| `method` | string | no | HTTP method the target URL expects (`GET`, `POST`, etc.). Advisory metadata for clients; the resolver itself only issues redirects, not requests. |
+| `public` | boolean | no | Indicates the URL itself is safe to publish in a public directory. Distinct from `accessRole` and `encryptionMethod`, which govern who may *retrieve or decrypt* the resource. A link may be `public: true` while still requiring an authorised role to fetch the content. An explicit `public: false` round-trips and is preserved separately from "not set". |
+| `rel` | string[] | no | Additional link relation types qualifying the link beyond its primary `linkType`. The reserved value `predecessor-version` is silently stripped from publisher input; the server emits it itself on predecessor entries derived from version history. |
+| `linkId` | string (UUID) | server-generated | Unique identifier assigned at registration time. Read-only; used to address the variant via the [Link Management](#link-management) endpoints. |
+
+The composite key uniquely identifying a variant is `(targetUrl, linkType, mimeType, context)`. `hreflang`, default flags, and the other fields are NOT part of the key. See [Append-only behaviour](#append-only-behaviour) below.
 
 :::caution Link type validation
 Every `linkType` value is validated against a namespace-specific vocabulary.

--- a/documentation/docs/migration-guides/v4.md
+++ b/documentation/docs/migration-guides/v4.md
@@ -41,6 +41,16 @@ The retired fields are:
 
 `defaultMimeType` is still scoped per `(linkType + context)` at registration time. Resolution does not consult `context` at request time (no request-side context signal), so the cascade returns the first hreflang-matching variant whose flag is set. See the [How It Works](../understanding-the-service/how-it-works) precedence table for the full cascade.
 
+### Additive variant fields and MIME loosening
+
+These are additive and do not require any upgrade action; publishers can opt in to them once on v4.
+
+- **`public: boolean`** on each variant. Indicates that the URL itself is safe to publish in a public directory. Distinct from `accessRole` and `encryptionMethod`, which govern who may retrieve or decrypt the resource. A variant may be `public: true` while still requiring an authorised role to fetch the content. An explicit `public: false` round-trips and is preserved separately from "not set".
+- **`rel: string[]`** on each variant. Carries additional link relation types qualifying the variant beyond its primary `linkType`. The reserved value `predecessor-version` is silently stripped from publisher input; the server emits it itself on predecessor entries derived from version history.
+- **MIME type loosening.** v3 rejected `mimeType` values outside a curated list; v4 accepts any RFC 6838 well-formed media type, including custom and vendor-prefixed types such as `application/vnd.acme.sbom+json`. Registrations that previously failed with a `400` on uncommon MIME types now succeed.
+
+The full per-variant field reference lives in the [Developer Guide](../developer-guide/#variant-fields).
+
 ## Before you upgrade
 
 ### 1. Stop the v3 service

--- a/documentation/docs/understanding-the-service/how-it-works.md
+++ b/documentation/docs/understanding-the-service/how-it-works.md
@@ -73,9 +73,11 @@ and is described by:
 
 - **Link type** — What kind of information this is (e.g. `acme:sustainabilityInfo`)
 - **Target URL** — Where the information lives (e.g. `https://example.com/sustainability-report`)
-- **Language** — The language of the resource (e.g. `en` for English)
+- **Language** — BCP 47 tags the variant serves, via `hreflang[]` (e.g. `["en", "en-AU"]`)
 - **Context** — A regional or situational qualifier (e.g. `au` for Australia)
-- **MIME type** — The format of the resource (e.g. `text/html`)
+- **MIME type** — Any well-formed RFC 6838 media type (e.g. `text/html`, `application/vnd.acme.sbom+json`)
+
+A variant can also carry optional metadata: `public` (the URL is safe to publish in a public directory), `rel` (additional link relation types beyond the primary `linkType`), `accessRole` (UNTP variant-based-disclosure roles), `encryptionMethod`, and `method`. The full list lives in the [Developer Guide](../developer-guide/#variant-fields).
 
 You can register multiple responses for the same identifier,
 covering different link types, languages, formats, and contexts.

--- a/documentation/versioned_docs/version-4.0.0/developer-guide/index.md
+++ b/documentation/versioned_docs/version-4.0.0/developer-guide/index.md
@@ -178,9 +178,11 @@ Each registration targets a namespace + identifier key type + identifier key
 (and optionally a qualifier path),
 and contains one or more **responses** --
 each pointing to a different URL with its own link type,
-language tag (e.g., `en`, `fr-CA`),
+language tags (BCP 47 entries in `hreflang[]` such as `en`, `en-AU`, or `fr-CA`),
 MIME type (the content format, such as `text/html` or `application/pdf`),
 and context (typically a geographic region code such as `au` or `us`).
+The full set of accepted per-variant fields is summarised under
+[Variant fields](#variant-fields) below.
 
 ### Register links
 
@@ -237,11 +239,37 @@ A successful `201` response:
 }
 ```
 
-:::note Deprecation notice
-The `description` field replaces the deprecated `itemDescription` field.
-Both are accepted for backwards compatibility, but `description` is preferred.
-`itemDescription` will be removed in v3.0.
+:::note `description` field
+The top-level `description` field replaces the legacy `itemDescription` field.
+Both are accepted for backwards compatibility, but `description` is preferred;
+`itemDescription` was deprecated in v3.0.0 and remains accepted as an alias.
 :::
+
+#### Variant fields
+
+Every entry in the `responses[]` array (a "variant") accepts the following fields. The full Swagger UI at `/api` is generated from the same DTOs and is the authoritative source for shape and validation.
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `linkType` | string | yes | The link relation type (`prefix:key`, e.g. `acme:sustainabilityInfo`). Validated against the vocabulary for the namespace's prefix. |
+| `title` | string | yes | Human-readable label for the link. |
+| `targetUrl` | string (URL) | yes | The URL the link resolves to. |
+| `mimeType` | string | yes | Any RFC 6838 well-formed media type (e.g. `text/html`, `application/pdf`, `application/vnd.acme.sbom+json`). Custom and vendor-prefixed types are accepted; the value is not constrained to a registry. |
+| `context` | string | yes | Context qualifier (typically a regional code such as `au`, `us`, or `eu`). Part of the composite key. |
+| `hreflang` | string[] | no | BCP 47 language tags advertised by this variant. A single variant can serve multiple tags. Matching is case-insensitive per RFC 4647 §2.1. |
+| `defaultLinkType` | boolean | yes | Marks this variant as the default for resolution requests that omit `linkType`. Only one variant per registration may set this to `true`. |
+| `defaultContext` | boolean | yes | Marks this variant as the publisher's canonical fallback for its link type when no variant matches the requested language. Only one variant per link type may set this to `true`. |
+| `defaultMimeType` | boolean | yes | Marks this variant as the preferred MIME type within its `(linkType, context)` group. Only one variant per `(linkType, context)` may set this to `true`. |
+| `fwqs` | boolean | yes | Forward query string flag (see [`fwqs`](#forward-query-string-fwqs) above). |
+| `active` | boolean | yes | Whether the variant is served at resolution time. Set to `false` on soft delete; remains in the document but is omitted from the linkset. |
+| `accessRole` | string[] | no | UNTP access roles that may retrieve this variant under variant-based disclosure. Values follow the URI pattern `untp:accessRole#RoleName` (`Anonymous`, `Customer`, `Regulator`, `Recycler`, `Auditor`, `Owner`); shorthand forms such as `customer` are expanded at resolution time. |
+| `encryptionMethod` | string | no | Encryption applied to the target content. One of `none`, `AES-128`, `AES-256`. Documents the encryption scheme; the resolver does not perform decryption itself (see `fwqs` + `decryptionKey` for key forwarding). |
+| `method` | string | no | HTTP method the target URL expects (`GET`, `POST`, etc.). Advisory metadata for clients; the resolver itself only issues redirects, not requests. |
+| `public` | boolean | no | Indicates the URL itself is safe to publish in a public directory. Distinct from `accessRole` and `encryptionMethod`, which govern who may *retrieve or decrypt* the resource. A link may be `public: true` while still requiring an authorised role to fetch the content. An explicit `public: false` round-trips and is preserved separately from "not set". |
+| `rel` | string[] | no | Additional link relation types qualifying the link beyond its primary `linkType`. The reserved value `predecessor-version` is silently stripped from publisher input; the server emits it itself on predecessor entries derived from version history. |
+| `linkId` | string (UUID) | server-generated | Unique identifier assigned at registration time. Read-only; used to address the variant via the [Link Management](#link-management) endpoints. |
+
+The composite key uniquely identifying a variant is `(targetUrl, linkType, mimeType, context)`. `hreflang`, default flags, and the other fields are NOT part of the key. See [Append-only behaviour](#append-only-behaviour) below.
 
 :::caution Link type validation
 Every `linkType` value is validated against a namespace-specific vocabulary.

--- a/documentation/versioned_docs/version-4.0.0/migration-guides/v4.md
+++ b/documentation/versioned_docs/version-4.0.0/migration-guides/v4.md
@@ -41,6 +41,16 @@ The retired fields are:
 
 `defaultMimeType` is still scoped per `(linkType + context)` at registration time. Resolution does not consult `context` at request time (no request-side context signal), so the cascade returns the first hreflang-matching variant whose flag is set. See the [How It Works](../understanding-the-service/how-it-works) precedence table for the full cascade.
 
+### Additive variant fields and MIME loosening
+
+These are additive and do not require any upgrade action; publishers can opt in to them once on v4.
+
+- **`public: boolean`** on each variant. Indicates that the URL itself is safe to publish in a public directory. Distinct from `accessRole` and `encryptionMethod`, which govern who may retrieve or decrypt the resource. A variant may be `public: true` while still requiring an authorised role to fetch the content. An explicit `public: false` round-trips and is preserved separately from "not set".
+- **`rel: string[]`** on each variant. Carries additional link relation types qualifying the variant beyond its primary `linkType`. The reserved value `predecessor-version` is silently stripped from publisher input; the server emits it itself on predecessor entries derived from version history.
+- **MIME type loosening.** v3 rejected `mimeType` values outside a curated list; v4 accepts any RFC 6838 well-formed media type, including custom and vendor-prefixed types such as `application/vnd.acme.sbom+json`. Registrations that previously failed with a `400` on uncommon MIME types now succeed.
+
+The full per-variant field reference lives in the [Developer Guide](../developer-guide/#variant-fields).
+
 ## Before you upgrade
 
 ### 1. Stop the v3 service

--- a/documentation/versioned_docs/version-4.0.0/understanding-the-service/how-it-works.md
+++ b/documentation/versioned_docs/version-4.0.0/understanding-the-service/how-it-works.md
@@ -73,9 +73,11 @@ and is described by:
 
 - **Link type** — What kind of information this is (e.g. `acme:sustainabilityInfo`)
 - **Target URL** — Where the information lives (e.g. `https://example.com/sustainability-report`)
-- **Language** — The language of the resource (e.g. `en` for English)
+- **Language** — BCP 47 tags the variant serves, via `hreflang[]` (e.g. `["en", "en-AU"]`)
 - **Context** — A regional or situational qualifier (e.g. `au` for Australia)
-- **MIME type** — The format of the resource (e.g. `text/html`)
+- **MIME type** — Any well-formed RFC 6838 media type (e.g. `text/html`, `application/vnd.acme.sbom+json`)
+
+A variant can also carry optional metadata: `public` (the URL is safe to publish in a public directory), `rel` (additional link relation types beyond the primary `linkType`), `accessRole` (UNTP variant-based-disclosure roles), `encryptionMethod`, and `method`. The full list lives in the [Developer Guide](../developer-guide/#variant-fields).
 
 You can register multiple responses for the same identifier,
 covering different link types, languages, formats, and contexts.


### PR DESCRIPTION
The v4.0.0 release-prep PR (#127) shipped without documenting three landings that are part of v4 but went unmentioned in the release notes and the docs site: the additive `public` and `rel` variant fields, and the MIME type loosening (the service now accepts any RFC 6838 well-formed media type, not the previous curated list). A canonical per-variant field reference was also missing entirely; the developer-guide described variants through a single registration example, leaving `method`, `encryptionMethod`, and registration-time `accessRole` undocumented since v2.0.0.

This PR fills those gaps without changing any code, version, or release tag. v4.0.0 already supports everything described here; the docs were lagging the binary.

## What this PR changes

- `documentation/docs/developer-guide/index.md`: new **Variant fields** reference table covering every accepted field with type, required/optional, and contract notes. Includes the `predecessor-version` strip semantics on `rel`. MIME paragraph and prose intro updated for RFC 6838 acceptance and `hreflang[]`. Pointer to the Swagger UI as the authoritative DTO surface. Stale "itemDescription will be removed in v3.0" note corrected (the field remains accepted as an alias, confirmed by the existing e2e suite).
- `documentation/docs/understanding-the-service/how-it-works.md`: Language and MIME bullets in the variant-model section updated; new paragraph naming `public`, `rel`, `accessRole`, `encryptionMethod`, `method` and linking to the field reference.
- `documentation/docs/migration-guides/v4.md`: new `### Additive variant fields and MIME loosening` subsection alongside the existing breaking-change subsections in "What changed".
- `RELEASE_NOTES.md`: peer subsection in v4.0.0's "What changed" block covering the same three additive landings.
- `documentation/versioned_docs/version-4.0.0/...`: mirror of every change above so the served `4.0.0` docs page matches the current docs. `diff -rq documentation/docs/ documentation/versioned_docs/version-4.0.0/` is clean.

## What this PR does NOT change

- `version.json`, `app/package.json`, `documentation/package.json`, `documentation/versions.json`, `documentation/docusaurus.config.ts`. v4.0.0 stays at v4.0.0.
- No `app/` code. No new endpoints. No DTO changes.
- The `:4.0.0` and `:latest` Docker tags are unchanged (they move on tag pushes, not master pushes).

## Test plan

- [x] `yarn build` in `documentation/` (Docusaurus build clean, no broken links).
- [x] `diff -rq documentation/docs/ documentation/versioned_docs/version-4.0.0/` returns no differences.
- [x] Field reference cross-checked against `app/src/modules/link-registration/dto/link-registration.dto.ts` and `app/src/modules/link-registration/constants/untp-enums.ts` (every DTO-accepted field is in the table; enum values for `encryptionMethod` and `accessRole` shorthand expansion are accurate).
- [x] `itemDescription` alias claim verified against the existing e2e suite at `app/test/link-registration/item-description-backwards-compat.e2e-spec.ts`.
